### PR TITLE
Fix wording of preprocessor section.

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -1070,9 +1070,9 @@ Identifiers defined in the top-level namespace are globally visible.
 Declarations within a ```parser``` or ```control``` are private and cannot be referred to from outside of the enclosing ```parser``` or ```control```.
 
 # P4 data types { #sec-p4-type }
-P4 is a strongly-typed language; all values are statically typed. Programs that do not pass type-checking are invalid.  Some values can be converted to a different type by using casts. To make the user intent clear, implicit casts are allowed in very few circumstances. Moreover, the range of casts available is intentionally restricted.
+P$4_{16}$ is a statically-typed language. Programs that do not pass the type checker are invalid and must be rejected by the compiler. Some values can be converted to a different type using casts. To make user intents clear, implicit casts are only allowed in a few circumstances and the range of casts available is intentionally restricted.
 
-P4 supports several base types and allows the construction of derived types.
+P4 provides a number of base types as well as type operators that construct derived types.
 
 ##	Base types { #sec-base-types }
 P4 supports the following built-in base types:


### PR DESCRIPTION
This commit changes "must" to "should" to allow future versions of the specification to avoid mandating preprocessor functionality.

Also reworded Section 7.2.1 to make inclusion of `core.p4` optional.

This closes #30.
