### PR TITLE
Fix minor typos.

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -3020,7 +3020,7 @@ tableProperty
     | optAnnotations IDENTIFIER '=' initializer ';'
     ;
 ~ End P4Grammar
-Table parameters cannot be direction-less (they must be ```in```, ```out``` or ```inout```).
+Table parameters cannot be directionless (they must be ```in```, ```out``` or ```inout```).
 The standard table properties are the following:
 
 - ```key```: An expression that describes how the key used for look-up is computed.
@@ -3295,7 +3295,7 @@ From this grammar fragment we infer that a ```parser``` declaration can have two
 -	The runtime parser parameters
 -	Optional parser constructor parameters (```optConstructorParameters```)
 
-All constructor parameters must be direction-less (i.e., they cannot be ```in```, ```out``` or ```inout```). When instantiating a parser one has to supply expressions that can be fully evaluated at compilation time for all ```optConstructorParameters```.
+All constructor parameters must be directionless (i.e., they cannot be ```in```, ```out``` or ```inout```). When instantiating a parser one has to supply expressions that can be fully evaluated at compilation time for all ```optConstructorParameters```.
 
 Consider the following example:
 ~ Begin P4Example

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -77,7 +77,7 @@ instantiation
     : annotations typeRef '(' argumentList ')' name ';'
     ;
 
-soptConstructorParameters
+optConstructorParameters
     : /* empty */
     | '(' parameterList ')'
     ;


### PR DESCRIPTION
* Modified two occurrences of "direction-less" to "directionless" to
  make spelling consistent across the document.

* Modified "soptConstructorParameters" to "optConstructorParameters".