### PR TITLE
Tweak wording on header stacks.

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -2116,21 +2116,21 @@ necessarily contiguous.
 
 P4 provides several computations that can only be applied to header
 stacks. Given an expression ```hs``` of type header stack, the
-following expressions are legal: 
+following expressions are legal in any context:
 
 - ```hs.empty```: result is a Boolean value, which is ```true``` when all validity bits in the stack are false.
 - ```hs.full```: result is a Boolean value, which is ```true``` if all validity bits in the stack are true.
-- ```hs.pop_front(int count)```: shift "left" by ```count``` (e.g., element with index ```count``` is moved to index ```0```). The last ```count``` elements become invalid.
-- ```hs.push_front(int count)```: shift "right" by ```count```. The first ```count``` elements become invalid. The last ```count``` elements in the stack are discarded.
 
 In addition, the following expressions are legal in parsers,
 
 - ```hs.next```: result is a reference to the lowest-index header in the stack which does not have a validity bit set. If the stack is full, evaluating this expression results in a transition to the ```reject``` state, setting the error to ```error.StackFull```. If ```hs``` is an l-value, the result is also an l-value.
 - ```hs.last```: result is a reference to the largest-index header in the stack which does have the validity bit set. If the stack is empty evaluation of this expression results in a transition to reject, setting the error to ```error.StackEmpty```. If ```hs``` is an l-value, the result is also an l-value.
 
-and the following expression is legal in control blocks:
+and the following expressions are legal in control blocks:
 
 - ```hs[index]```: result is a reference to the header at the specified position within the stack; if ```hs``` is an l-value, the result is also an l-value. The header may be invalid. Some targets may impose the constraint that the index expression evaluates to a compile-time known value. Accessing a header stack with an index out of bounds produces an undefined result.
+- ```hs.pop_front(int count)```: shift "left" by ```count``` (e.g., element with index ```count``` is moved to index ```0```). The last ```count``` elements become invalid.
+- ```hs.push_front(int count)```: shift "right" by ```count```. The first ```count``` elements become invalid. The last ```count``` elements in the stack are discarded.
 
 The restrictions on which expressions can appear in parsers and control blocks are designed to ensure that stacks remain contiguous in the parser, but to allow random access in control blocks. 
 


### PR DESCRIPTION
Implement @akeep's suggested solution to header stacks,
- stack-like operations in parsers
- array-like operations in control
to ensure they contain contiguous values.

Addresses the last remaining issue in #59.