### PR TITLE
Action params fix

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -3044,7 +3044,7 @@ action Forward_a(out bit<9> outputPort)(bit<9> port) {
 
 Actions may declare two sets of parameters: the first indicate data-plane parameters (i.e., ```outputPort``` above) while the second (i.e., ```port``` above) indicate action data. Action parameters cannot have ```extern``` types. For actions that appear in a table actions list (described in Section [#sec-table-action-list]), the action data are set by the control plane. 
 
-As a syntactic convenience, P4 allows all parameters to be declared within a single set of parentheses. Any directionless parameters are interpreted as the action data parameters. For instance, the above action could be written as follows:
+As a syntactic convenience, P4 allows all parameters to be declared within a single set of parentheses. In this case, all directionless parameters must come at the end of the list of parameters and are interpreted as the action data parameters. For instance, the above action could be written as follows:
 ~ Begin P4Example
 action Forward_a(out bit<9> outputPort, bit<9> port) {
     outputPort = port;


### PR DESCRIPTION
This pull requests attempts to implement the fix to #76 discussed at the 11/14 design meeting.

* Allow two sets of parentheses for action declarations and instantiations.

* Also allow one set of parentheses as a syntactic convenience in both declarations and instantiations, with the understanding that directionless parameters indicate action data.

* Require all parameters for `default_action`s and lift the requirement that it be an existing element of the list of actions.

Note that this has not yet been implemented in `p4c`.