### PR TITLE
Delete cut-and-paste typo

### DIFF
--- a/p4-14/v1.0.3/tex/p4.tex
+++ b/p4-14/v1.0.3/tex/p4.tex
@@ -2983,8 +2983,6 @@ rel_op ::= > | >= | == | <= | < | !=
 \end{lstlisting}
 %%endbnf
 
-In many cases, it is convenient to specify a sequence of fields. For example, 
-
 Operator precedence and associativity follows C programming conventions.
 As described in Section~\ref{sec:parserop}, the parser returns the name 
 of the control function to begin \matchaction processing.  When that function 


### PR DESCRIPTION
The sentence fragment

> In many cases, it is convenient to specify a sequence of fields. For example,

appears in Section 12. I believe this is a cut-and-paste error from
Section 2.4.

This commit simply deletes the second occurrence.