### PR TITLE
Small typographical fixes

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -4020,18 +4020,16 @@ on the specification.
 
 ##	Portable Switch Architecture
 
-Portability and composability are critical to P4's long-term success. To that
-end, the draft specification for an architecture definition that enables
-programmers to write composable P4 programs, called the [_Portable Switch
-Architecture_](http://p4.org/documents/psa.pdf) (PSA), is available for
-comments. For example:
-
+Portability and composability are critical to P4's long-term success:
 - Composability: implement different features, such as In-band Network
   Telemetry (INT), Network Virtualization, and Load Balancing in separate P4
   programs written for the PSA, should easily interoperate when invoked from a
   toplevel program.
 - Portability: a P4 implementation of a certain function, such as INT, against
   PSA should work consistently across architectures that support the PSA.
+To that end, a specification for an architecture definition that enables 
+programmers to write composable P4 programs, called the _Portable Switch 
+Architecture_, is being developed by the Architecture Working Group.
 
 ##	Populate table entries at compile time
 


### PR DESCRIPTION
These were noticed by from Andy Fingerhut:

* Wrong width on example cube expression

* Name of `headerLvalue` parameter in two-argument `extract` function

* Clarify that language forbids instantiating parsers in controls, not the architecture.

* Link to PSA document doesn't exist.

* Trivial typos.