### PR TITLE
Grammar, typo, punctuation, and P4 syntax fixes.

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -285,7 +285,6 @@ P4 programs can also interact with fixed-function objects by invoking their serv
 
 ~ Begin P4Example
 extern Checksum16 {
-    Checksum16();
     void clear();           // prepare unit for computation
     void update<T>(T data); // add data to checksum
     void remove<T>(T data); // remove data from existing checksum
@@ -389,7 +388,6 @@ package VSS<H>(Parser<H> p,
 // Architecture-specific objects that can be instantiated
 // Checksum unit
 extern Checksum16 {
-    Checksum16();
     void clear();           // prepare unit for computation
     void update<T>(T data); // add data to checksum
     void remove<T>(T data); // remove data from existing checksum
@@ -582,15 +580,15 @@ control TopPipe(inout Parsed_packet headers,
       action Drop_action()
       { outCtrl.outputPort = DROP_PORT; }
 
-      IPv4Address nextHop;
-
      /**
       * Set the next hop and the output port.
       * Decrements ipv4 ttl field.
       * @param ivp4_dest ipv4 address of next hop
       * @param port output port
       */
-      action Set_nhop(IPv4Address ipv4_dest, PortId port) {
+      action Set_nhop(out IPv4Address nextHop,
+                      IPv4Address ipv4_dest,
+                      PortId port) {
           nextHop = ipv4_dest;
           headers.ip.ttl = headers.ip.ttl - 1;
           outCtrl.outputPort = port;
@@ -600,12 +598,13 @@ control TopPipe(inout Parsed_packet headers,
       * Computes address of next IPv4 hop and output port
       * based on the IPv4 destination of the current packet.
       * Decrements packet IPv4 TTL.
+      * @param nextHop IPv4 address of next hop
       */
-     table ipv4_match {
+     table ipv4_match(out IPv4Address nextHop) {
          key = { headers.ip.dstAddr: lpm; }  // longest-prefix match
          actions = {
               Drop_action;
-              Set_nhop;
+              Set_nhop(nextHop);
          }
 
          size = 1024;
@@ -621,7 +620,7 @@ control TopPipe(inout Parsed_packet headers,
      /**
       * Check packet TTL and send to CPU if expired.
       */
-     table check_ttl {
+     table check_ttl() {
          key = { headers.ip.ttl: exact; }
          actions = { Send_to_cpu; NoAction; }
          const default_action = NoAction; // defined in core.p4
@@ -636,8 +635,9 @@ control TopPipe(inout Parsed_packet headers,
      /**
       * Set the destination Ethernet address of the packet
       * based on the next hop IP address.
+      * @param nextHop IPv4 address of next hop.
       */
-      table dmac {
+      table dmac(in IPv4Address nextHop) {
           key = { nextHop: exact; }
           actions = {
                Drop_action;
@@ -657,7 +657,7 @@ control TopPipe(inout Parsed_packet headers,
       /**
        * Set the source mac address based on the output port.
        */
-      table smac {
+      table smac() {
            key = { outCtrl.outputPort: exact; }
            actions = {
                 Drop_action;
@@ -668,18 +668,20 @@ control TopPipe(inout Parsed_packet headers,
       }
 
       apply {
+          IPv4Address nextHop; // temporary variable
+
           if (parseError != error.NoError) {
               Drop_action();  // invoke drop directly
               return;
           }
 
-          ipv4_match.apply(); // Match result will go into nextHop
+          ipv4_match.apply(nextHop); // Match result will go into nextHop
           if (outCtrl.outputPort == DROP_PORT) return;
 
           check_ttl.apply();
           if (outCtrl.outputPort == CPU_OUT_PORT) return;
 
-          dmac.apply();
+          dmac.apply(nextHop);
           if (outCtrl.outputPort == DROP_PORT) return;
 
           smac.apply();
@@ -3977,7 +3979,6 @@ There are no built-in constructs in P4~16~ for manipulating packet checksums. We
 For example, one could provide an incremental checksum unit ```Checksum16``` (also described in the VSS example in Section [#sec-vss-extern]) for computing 16-bit one's complement using an ```extern``` object with a signature such as:
 ~ Begin P4Example
 extern Checksum16 {
-    Checksum16();
     void clear();           // prepare unit for computation
     void update<T>(T data); // add data to checksum
     void remove<T>(T data); // remove data from existing checksum


### PR DESCRIPTION
Some of the rewording suggestions are judgement calls, but to my
native English speaker's ears the proposed changes sound more natural.

For the change involving the paragraph containing ```Checksum16```,
Madoko apparently formats it differently if that text appears first on
an input line, vs. later in a line.  The formatted PDF output looks
more like what I would expect with the change I made there.

In the first sample P4 program, I ran it through a recent version of
the p4c compiler.  It complained about these lines:

    Checksum16() ck;

but gave no such complaints when the () was removed.  I did not dig
deep to figure out whether that was a problem with p4c.