### PR TITLE
Add constructor for Checksum16, remove table parameters from sample p…

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -285,10 +285,10 @@ P4 programs can also interact with fixed-function objects by invoking their serv
 
 ~ Begin P4Example
 extern Checksum16 {
-    Checksum16();           // constructor
-    void clear();           // prepare unit for computation
-    void update<T>(T data); // add data to checksum
-    void remove<T>(T data); // remove data from existing checksum
+    Checksum16();              // constructor
+    void clear();              // prepare unit for computation
+    void update<T>(in T data); // add data to checksum
+    void remove<T>(in T data); // remove data from existing checksum
     bit<16> get(); // get the checksum for the data added since last clear
 }
 ~ End P4Example
@@ -389,10 +389,10 @@ package VSS<H>(Parser<H> p,
 // Architecture-specific objects that can be instantiated
 // Checksum unit
 extern Checksum16 {
-    Checksum16();           // constructor
-    void clear();           // prepare unit for computation
-    void update<T>(T data); // add data to checksum
-    void remove<T>(T data); // remove data from existing checksum
+    Checksum16();              // constructor
+    void clear();              // prepare unit for computation
+    void update<T>(in T data); // add data to checksum
+    void remove<T>(in T data); // remove data from existing checksum
     bit<16> get(); // get the checksum for the data added since last clear
 }
 ~ End P4Example
@@ -473,7 +473,7 @@ methods:
 - ```clear()``` --- prepares the unit for a new computation
 - ```update<T>(in T data)``` --- add some data to be checksummed. The data must be either a bit-string, a header-typed value, or a ```struct``` containing such values. The fields in the header/struct are concatenated in the order they appear in the type declaration.
 - ```get()``` --- returns the 16-bit one's complement checksum. When this function is invoked the checksum must have received an integral number of bytes of data.
-- ```remove<T>(T data)``` --- under the assumption that ```data``` was used for computing the current checksum, ```data``` is removed from the checksum (“undo”).
+- ```remove<T>(in T data)``` --- under the assumption that ```data``` was used for computing the current checksum, ```data``` is removed from the checksum (“undo”).
 
 
 ##	A complete Very Simple Switch program { #sec-vss-all }
@@ -3982,10 +3982,10 @@ There are no built-in constructs in P4~16~ for manipulating packet checksums. We
 For example, one could provide an incremental checksum unit ```Checksum16``` (also described in the VSS example in Section [#sec-vss-extern]) for computing 16-bit one's complement using an ```extern``` object with a signature such as:
 ~ Begin P4Example
 extern Checksum16 {
-    Checksum16();           // constructor
-    void clear();           // prepare unit for computation
-    void update<T>(T data); // add data to checksum
-    void remove<T>(T data); // remove data from existing checksum
+    Checksum16();              // constructor
+    void clear();              // prepare unit for computation
+    void update<T>(in T data); // add data to checksum
+    void remove<T>(in T data); // remove data from existing checksum
     bit<16> get(); // get the checksum for the data added since last clear
 }
 ~ End P4Example


### PR DESCRIPTION
…rogram

With these changes, latest 2017-Apr-04 p4c gives only errors for the two ck.update() calls.  I don't know whether that is an issue with compiler or the sample program.

```
p4example.p4(67): error: : not a compile-time constant when binding to data
        ck.update(p.ip);
                  ^^^^
very_simple_model.p4(68)
    void update<T>(T data);
                     ^^^^
p4example.p4(201): error: : not a compile-time constant when binding to data
            ck.update(p.ip);
                      ^^^^
very_simple_model.p4(68)
    void update<T>(T data);
                     ^^^^
```