### PR TITLE
Corrections to table list of actions description

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -3389,9 +3389,11 @@ in the table actions list, with all its arguments bound.
 Entries in a table are matched in a priority order, where lower numbers
 correspond to higher priorities. Priority may be specified or computed in one
 of the following ways:
-- specified with an annotation, ``@priority(value)```, where ```value``` must
-  evaluate to a positive integer compile-time know value; or
-- computed based the program order of the entries -- entries occuring first have higher priority.
+
+- specified with an annotation, ```@priority(value)```, where ```value``` must
+  evaluate to a positive integer compile-time known value; or
+- computed based on the program order of the entries -- entries occuring first have higher priority.
+
 Priority annotations take precedence over computed priorities.
 
 Depending on the ```match_kind``` of the keys, key set expressions may define
@@ -3456,8 +3458,8 @@ program, with decreasing priority levels. Entries demonstrate the use of
 the ```@priority``` annotation, which inverts their priority order, that is
 entry 4 in lexicographical order is set to have priority 5, and entry 5 is set
 to prioirty 4. A packet with the ternary field set to 0x1211 should be directed
-to port 5 rather than port 4, since the entry ```(0x04, 01311 &&& 0x02F0)```
-will have priority over the entry ```(0x04, 01211 &&& 0x02F0)```.
+to port 5 rather than port 4, since the entry ```(0x04, 0x1311 &&& 0x02F0)```
+will have priority over the entry ```(0x04, 0x1211 &&& 0x02F0)```.
 
 ####	Additional table properties
 


### PR DESCRIPTION
Mostly incorrect use of Madoko markup.