### PR TITLE
Fix section label clashes

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -5850,7 +5850,7 @@ the global scope, have the same local and fully-qualified names.  The
 local names of controllable entities and enclosing constructs are
 derived from the syntax of a P4 program as follows.
 
-#### Tables
+#### Tables { #sec-cp-tables }
 
 For each ```table``` construct, its syntactic name becomes the local
 name of the table.  For example:
@@ -5863,7 +5863,7 @@ control c(...)() {
 
 This table's local name is ```t```.
 
-#### Keys
+#### Keys { #sec-cp-keys }
 
 Syntactically, table keys are expressions.  For simple expressions,
 the local key name can be generated from the expression itself.  In
@@ -5907,7 +5907,7 @@ table t {
 Here, the ```@name("f1_mask")``` annotation assigns the local name ```"f1_mask"```
 to this key.
 
-#### Actions
+#### Actions { #sec-cp-actions }
 
 For each ```action``` construct, its syntactic name is the local name
 of the action.  For example:
@@ -5920,7 +5920,7 @@ control c(...)() {
 
 This action's local name is ```a```.
 
-#### Instances
+#### Instances { #sec-cp-instances }
 
 The local names of ```extern```, ```parser```, and ```control```
 instances are derived based on how the instance is used.  If the


### PR DESCRIPTION
Do not merge until after #201.

Add labels to subsections of control-plane names that were causing
conflicts with `sec-tables` and `sec-actions` labels elsewhere. Also
added labels to other subsections (e.g. `sec-cp-keys`) to avoid the
possibility of the same error in the future.

Fixes #199 
