### PR TITLE
Avoid LaTeX warnings of undefined cross-refs

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -1241,7 +1241,9 @@ name
     ;
 ~ End P4Grammar
 
-### Comments { #sec-comments } Comments are Java style:
+### Comments { #sec-comments }
+
+Comments are Java style:
 
 - Single-line comments, spanning to the end of line, introduced by ```//```
 - Multi-line comments, enclosed between ```/*``` and ```*/```


### PR DESCRIPTION
Apparently having this text on the same line was causing some warnings
in the LaTeX output about undefined references.