### PR TITLE
Fix a couple more instances of incorrect Madoko markup

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -1251,8 +1251,9 @@ not as a single ```bit``` token.
 
 ### Literal constants { #sec-literals }
 
-#### Boolean Literals { #sec-boolean-literals } There are two Boolean
-literal constants: ```true``` and ```false```.
+#### Boolean Literals { #sec-boolean-literals }
+
+There are two Boolean literal constants: ```true``` and ```false```.
 
 #### Integer literals { #sec-integer-literals }
 
@@ -1389,10 +1390,12 @@ language, and it significantly simplifies the implementation of
 compilers for P4, allowing compilers to use additional information
 about declared identifiers to resolve ambiguities.)
 
-### Stateful elements { #sec-stateful-elems } Most P4 constructs are
-stateless: given some inputs they produce a result that solely depends
-on these inputs. There are only two kinds of constructs that may
-retain information across packets (we call them "stateful"):
+### Stateful elements { #sec-stateful-elems }
+
+Most P4 constructs are stateless: given some inputs they produce a
+result that solely depends on these inputs. There are only two kinds
+of constructs that may retain information across packets (we call them
+"stateful"):
 
 - ```table```s. Tables are read-only for the data plane; their
   contents can only be modified by the control-plane


### PR DESCRIPTION
I think this fixes all occurrences of this particular kind of incorrect Madoko markup, which was causing the { #cross-ref-label } to appear in the PDF output.