### PR TITLE
Add header_union to list of derived types that create scopes

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -1371,9 +1371,8 @@ do not require terminating semicolons).
 Various constructs act as namespaces that create local scopes for
 names:
 
-- Derived type declarations (```struct```, ```header```,
-  ```header_union```, ```enum```) introduce local scopes for the field
-  names
+- Derived type declarations (```struct```, ```header```, ```header_union```, ```enum```)
+  introduce local scopes for the field names
 - Block statements introduce local lexically-enclosed scopes
 - ```parser```, ```table```, ```action```, and ```control``` blocks
   introduce local scopes
@@ -1448,8 +1447,8 @@ lvalue
 ~ End P4Grammar
 
 - Identifiers of a base or derived type.
-- Structure/header field member access operations (using the dot
-  notation).
+- Structure, header, and header union field member access operations
+  (using the dot notation).
 - References to elements within header stacks (see Section
   [#sec-expr-hs]): indexing, and references to ```last``` and ```next```.
 - The result of a bit-slice operator ```[m:l]```.
@@ -1477,9 +1476,9 @@ Each parameter is labeled with a direction:
      passed as a non-```in``` argument to a callee. ```in```
      parameters are always initialized by copying the value of the
      corresponding argument at call execution time.
--	```out``` parameters are uninitialized (parameters of type ```header```
-     are set to "invalid"); they are l-values (they can
-     be assigned to --- l-values are described in Section
+-    ```out``` parameters are uninitialized (parameters of type ```header```
+     or ```header_union``` are set to "invalid"); they are l-values
+     (they can be assigned to --- l-values are described in Section
      [#sec-lvalues]). The argument corresponding to an ```out```
      parameter in a call must be an l-value; after execution of a
      call, the value of an ```out``` parameter is copied out to the

--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -1371,8 +1371,9 @@ do not require terminating semicolons).
 Various constructs act as namespaces that create local scopes for
 names:
 
-- Derived type declarations (```struct```, ```header```, ```enum```)
-  introduce local scopes for the field names
+- Derived type declarations (```struct```, ```header```,
+  ```header_union```, ```enum```) introduce local scopes for the field
+  names
 - Block statements introduce local lexically-enclosed scopes
 - ```parser```, ```table```, ```action```, and ```control``` blocks
   introduce local scopes

--- a/p4-16/spec/p4.json
+++ b/p4-16/spec/p4.json
@@ -15,7 +15,7 @@
   "extraKeywords": [],
 
   "typeKeywords": [
-    "bool", "bit", "const", "enum", "entries", "header", "in", "inout", "int", "out", "struct", "varbit", "void"
+    "bool", "bit", "const", "enum", "entries", "header", "header_union", "in", "inout", "int", "out", "struct", "varbit", "void"
   ],
 
   "extraTypeKeywords": [],


### PR DESCRIPTION
Also to the list of typeKeywords in p4.json, which controls how color
highlighting is done in P4 code samples.