### PR TITLE
Mention header unions in 2 more places they ought to be

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -1979,7 +1979,7 @@ constructors. P4 provides the following type constructors:
 - ```control```
 - ```package```
 
-The types ```header```, ```enum```, ```struct```, ```extern```, ```parser```, ```control```,
+The types ```header```, ```header_union```, ```enum```, ```struct```, ```extern```, ```parser```, ```control```,
 and ```package``` can only be used in type declarations, where they
 introduce a new name for the type. The type can subsequently be
 referred to using this identifier.
@@ -2244,8 +2244,8 @@ struct Parsed_headers {
 ~ End P4Example
 
 The table below lists all types that may appear as members of headers,
-structs, and tuples.  Note that ```int``` means an infinite-precision
-integer, without a width specified.
+header unions, structs, and tuples.  Note that ```int``` means an
+infinite-precision integer, without a width specified.
 
 |-----|-----|-----|
 |                    | Container type |||
@@ -2556,8 +2556,8 @@ a type.  It should be only used in a position where one could write a
 bound type variable; it is similar to the Java `?` wildcard type.  The
 underscore can be used to reduce code complexity --- when it is not
 important what the type variable binds to (during type unification the
-don't care type can unify with any other type).  An example in given
-Section [#sec-arch-desc-example]).
+don't care type can unify with any other type).  An example is given
+Section [#sec-arch-desc-example].
 
 ## typedef { #sec-typedef }
 
@@ -5724,7 +5724,7 @@ The following are compile-time known values:
 - List expression where all components are compile-time known values.
 - Instances constructed by instance declarations (Section
   [#sec-instantiations]) and constructor invocations.
-- The following expressions (```+, -, *, / , %, cast, !, &, |, &&, ||, << , >> , ~``` , \ ```>, <, ==, !=, <=, >=, ++, [:]```)
+- The following expressions (```+```, ```-```, ```*```, ```/ ```, ```%```, ```cast```, ```!```, ```&```, ```|```, ```&&```, ```||```, ```<< ```, ```>> ```, ```~``` ```, ```\ ```>```, ```<```, ```==```, ```!=```, ```<=```, ```>=```, ```++```, ```[:]```)
   when their operands are all compile-time known values.
 - Identifiers declared as constants using the ```const``` keyword.
 


### PR DESCRIPTION
Also eliminate an unmatched right paren, and break up long text inside
``` into many shorter texts, because the long one Madoko forces to be
kept on one long line that doesn't fit in page width.