### PR TITLE
Another Madoko markup fix

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -278,8 +278,8 @@ _P4 conformance_ of a target is defined as follows: if a specific
 target T supports only a subset of the P4 programming language, say
 P4^T^, programs written in P4^T^ executed on the target should provide
 the exact same behavior as is described in this document. Note that P4
-conformant targets can provide arbitrary P4 language extensions and
-```extern``` elements.
+conformant targets can provide arbitrary P4 language extensions and ```extern```
+elements.
 
 ## Benefits of P4
 
@@ -3292,11 +3292,11 @@ a struct --- the list fields are assigned to the header fields in the
 order they appear.  In this case the header automatically becomes
 valid:
 
-```
+~ Begin P4Example
 header H { bit<32> x; bit<32> y; }
 H h;
 h = { 10, 12 };  // This also makes the header h valid
-```
+~ End P4Example
 
 ## Operations on header stacks { #sec-expr-hs }
 
@@ -4018,9 +4018,9 @@ used in the context of a `parserDeclaration` the
 `parserTypeDeclaration` cannot contain any type parameters.  I.e., the
 following declaration is illegal:
 
-```
+~ Begin P4Example
 parser P<H>(inout H data) { ... }
-```
+~ End P4Example
 
 At least one state, named ```start```, must be present in any ```parser```.
 A parser cannot contain two states with the same name. A parser cannot
@@ -4699,9 +4699,9 @@ when used in the context of a `controlDeclaration` the
 `controlTypeDeclaration` cannot contain any type parameters.  I.e.,
 the following declaration is illegal:
 
-```
+~ Begin P4Example
 control C<H>(inout H data) { ... }
-```
+~ End P4Example
 
 For a description of the ```optConstructorParameters```, which can be
 used to build parameterized control blocks, see Section


### PR DESCRIPTION
Only the first part of this change actually fixes badness in the PDF
output.  The others do not make any visual change in the output, but
they do eliminate the last of the occurrences of ``` as the first
non-whitespace on a line, except for the definitions of P4Example,
etc.