### PR TITLE
More Madoko markup fixes

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -783,8 +783,8 @@ preprocessor ```#include``` directives (see Section [#sec-preprocessor]).
 []{tex-cmd: "\indent"}
 The parser attempts to recognize an Ethernet header followed by an IPv4 header.
 If either of these headers are missing, parsing terminates with an
-error. Otherwise it extracts the information from these headers into a
-```Parsed_packet``` structure. The match-action pipeline is
+error. Otherwise it extracts the information from these headers into
+a ```Parsed_packet``` structure. The match-action pipeline is
 shown in Figure [#fig-vssmau]; it comprises four match-action units
 (represented by the P4 ```table``` keyword):
 
@@ -1359,9 +1359,9 @@ and must be instantiated before they can be used. However, although
 they are stateful, ```table```s do not need to be instantiated
 explicitly---declaring a ```table``` also creates an instance of
 it. This convention is designed to support the common case, since most
-tables are used just once. To have finer-grained control over when a
-```table``` is instantiated, a programmer can declare it within a
-```control```.
+tables are used just once. To have finer-grained control over when
+a ```table``` is instantiated, a programmer can declare it within
+a ```control```.
 
 Recall the example in Section [#sec-vss-all]: ```TopParser```, ```TopPipe```, ```TopDeparser```, ```Checksum16```,
 and ```Switch``` are types. There are two instances of ```Checksum16```, one in ```TopParser``` and
@@ -1616,8 +1616,8 @@ control p() {
 
 Identifiers defined in the top-level namespace are globally
 visible. Declarations within a ```parser``` or ```control``` are
-private and cannot be referred to from outside of the enclosing
-```parser``` or ```control```.
+private and cannot be referred to from outside of the enclosing ```parser```
+or ```control```.
 
 # P4 data types { #sec-p4-type }
 


### PR DESCRIPTION
I happened to notice that whenever Madoko has warnings like this early
in its output:

  warning: unable to read language definition: parsed_packet
  warning: unable to read language definition: table
  warning: unable to read language definition: control
  warning: unable to read language definition: parser

those occur because it found ```parsed_packet``` at the beginning of a
line somewhere in the input .mdk file.