### PR TITLE
reduce formality

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -145,10 +145,9 @@ Throughout this document, the following terms will be used:
   program.
 
 All terms defined explicitly in this document should not be understood
-to refer implicitly to similar terms defined elsewhere. Terms not
+to refer implicitly to similar terms defined elsewhere. Conversely, any terms not
 defined explicitly in this document should be interpreted according to
-ISO/IEC 2382:2015 (Information Technology - Vocabulary) or the other
-generally recognizable sources, such as IETF RFCs.
+generally recognizable sources---e.g., IETF RFCs.
 
 # Overview
 


### PR DESCRIPTION
I find the mention of ISO/IEC 2382 somewhat odd. It sets up expectations for a highly pedantic document, which this specification is not.

How do people feel about deleting it and replacing it with a more
direct statement that captures what we are trying to convey?