### PR TITLE
Simplify semantics of header union member setInvalidate() and assignment

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -3401,13 +3401,9 @@ operations can be used to manipulate `u`:
   sets the valid bit for all other headers to `false`, which implies
   that reading these headers will return an unspecified value.
 
-- `u.hi.setInvalid()`: if the valid bit for `hi` is `true` then sets it
-  to `false`, which implies that reading u.hi will return an unspecified
-  value). Alternatively, if the valid bit for `hi` is already `false`, then this
-  expression has no effect. In particular, if `u.hj` was valid for
-  some `hj` other than `hi` before `u.hi.setInvalid()` was invoked,
-  then `u.hj` remains valid and its fields continue to have the same
-  values as before.
+- `u.hi.setInvalid()`: if the valid bit for any member header of `u`
+  is `true` then sets it to `false`, which implies that reading any
+  member header of `u` will return an unspecified value.
 
 We can understand an assignment to a union
 


### PR DESCRIPTION
Motivation for the proposed change in semantics for header unions

Example P4 program fragment:

```
header_union u_t {
    h1_t h1;
    h2_t h2;
    h3_t h3;
    h4_t h4;
}

u_t u;
```

If you have a header_union variable u that is in one of many possible
states (e.g. perhaps member h1 is valid, or h2 is valid, or no members
are valid) and you wish to guarantee that all members of u become
invalid, the only way to write that given the current semantics is to
cause each member header to become invalidated, either with
setInvalid() or assignment from an invalid header of the appropriate
type.  Here is an example of the first way:

```
    u.h1.setInvalid();
    u.h2.setInvalid();
    u.h3.setInvalid();
    u.h4.setInvalid();
```

Moreover, this assignment:

```
    u.h1 = h1_variable;
```

has the surprising behavior of being a no-op if h1_variable is
invalid.  That is, if u.h2 was valid before the assignment above, it
will remain valid after the assignment.



With the new proposed semantics, _any one_ of the statements below
will invalidate all member headers of u:

```
    u.h1.setInvalid();
    u.h1 = h1_variable;  // where h1_variable is currently invalid

    // similarly for any of the other 3 members of u
```

If you want to implement the old behavior of u.h1.setInvalid(), it can
be done like this:

```
    if (u.h1.isValid()) {
        u.h1.setInvalid();
    }
```

If you want to implement the old behavior of 'u.h1 = h1_variable', it
can be done so as follows (although I would be surprised if anyone
_wanted_ this behavior for anything):

```
    if (h1_variable.isValid()) {
        u.h1 = h1_variable;
    } else {
        if (u.h1.isValid()) {
	    u.h1.setInvalid();
	} else {
            // no op
	}
    }
```
