### PR TITLE
Use goto instead of assignments to currentState in ParserModel defini…

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -1065,7 +1065,7 @@ following example:
 ParserModel.verify(bool condition, error err) {
     if (condition == false) {
         ParserModel.parserError = err;
-        ParserModel.currentState = reject;
+        goto reject;
     }
 }
 ~ End P4Pseudo
@@ -4039,11 +4039,9 @@ when one of the ```reject``` or ```accept``` states has been reached.
 ~ Begin P4Pseudo
 ParserModel {
     error       parseError;
-    state       currentState;
     onPacketArrival(packet p) {
         ParserModel.parseError = error.NoError;
-        ParserModel.currentState = start;
-        execute(ParserModel.currentState);
+        goto start;
     }
 }
 ~ End P4Pseudo
@@ -4130,7 +4128,7 @@ In terms of the `ParserModel`, the semantics of a `transition`
 statement can be formalized as follows:
 
 ~ Begin P4Example
-ParserModel.currentState = eval(stateExpression)
+goto eval(stateExpression)
 ~ End P4Example
 
 For example, this statement:
@@ -4258,7 +4256,7 @@ statement is given by:
 ParserModel.verify(bool condition, error err) {
     if (condition == false) {
         ParserModel.parserError = err;
-        ParserModel.currentState = reject;
+        goto reject;
     }
 }
 ~ End P4Pseudo


### PR DESCRIPTION
…tion

I am open to other variations on how to make this change, but these changes may be clear enough for now.  These changes eliminate all mentions of 'currentState' everywhere in the document.

I have re-read the section on Sub-parsers in light of these changes, and what is already written there seems good before and after these changes.