### PR TITLE
More Madoko markup fixes

### DIFF
--- a/p4-16/spec/P4-16-draft-spec.mdk
+++ b/p4-16/spec/P4-16-draft-spec.mdk
@@ -2885,8 +2885,7 @@ Each operand that participates in any of these operation must have
 type ```int```. With the exception of shift, binary operations cannot
 be used to combine values of type `int` with values of a fixed-width
 type. However, the compiler automatically inserts casts from ```int```
-to fixed-width types in certain situations---see Section [ #sec-casts
-].
+to fixed-width types in certain situations---see Section [#sec-casts].
 
 All computations on ```int``` values are carried out without loss of
 information. For example, multiplying two 1024-bit values may produce
@@ -3600,7 +3599,7 @@ typeArgumentList
 
 Function arguments are evaluated in order, left to right, before the
 function invocation takes place. The calling convention is
-copy-in/copy-out (Section [ #sec-calling-convention]). For generic functions the type
+copy-in/copy-out (Section [#sec-calling-convention]). For generic functions the type
 arguments can be explicitly specified in the function call. The compiler does not
 insert implicit casts for the arguments to methods or functions---the argument types
 must match the parameter types exactly.
@@ -4063,6 +4062,7 @@ parserState
     : optAnnotations STATE name
      '{' parserStatements transitionStatement '}'
     ;
+~ End P4Grammar
 
 Each state has a name and a body. The body consists of a sequence of
 statements that describe the processing performed when the parser
@@ -4072,7 +4072,7 @@ transitions to that state including:
 - Assignment statements,
 - Method calls, which serve several purposes:
   * Invoking functions (e.g., using ```verify``` to check the validity of data already parsed), and
-  * Invoking methods (e.g., extracting data out of packets or computing checksums) and other parsers (see Section [ #sec-invoke-subparser ]), and
+  * Invoking methods (e.g., extracting data out of packets or computing checksums) and other parsers (see Section [#sec-invoke-subparser]), and
 - Transitions to other states (discussed in Section [#sec-transition]).
 
 The syntax for parser statements is given by the following grammar rules:
@@ -5448,7 +5448,7 @@ header, header stack, `struct`, or header union to the output packet.
   invokes itself to each field.
 
 It is illegal to invoke `emit` on an expression of whose type is a
-base type, `enum`,or `error`.
+base type, `enum`, or `error`.
 
 We can define the meaning of the ```emit``` method in pseudo-code as
 follows:
@@ -5483,7 +5483,7 @@ Here we use the special ```valid$``` identifier to indicate the hidden
 valid bit of headers and ```fields$``` to indicate the list of fields
 for a struct or header union. We also use standard `for` notation to
 iterate through the elements of a stack `(e : data)` and list of
-fields for header stacsk and unions `(f : data.fields$)`.
+fields for header stacks and unions `(f : data.fields$)`.
 
 # Architecture description { #sec-arch-desc }
 
@@ -5899,7 +5899,7 @@ then the local name of the instance is ```c_inst```.
 
 Alternatively, if the instance is created as an actual argument, then its
 local name is the name of the formal parameter to which it will be
-bound. For example, if ```extern``` ```E``` and ```control`` ```C``` are declared as,
+bound. For example, if ```extern``` ```E``` and ```control``` ```C``` are declared as,
 
 ~ Begin P4Example
 extern E { ... }
@@ -6245,7 +6245,7 @@ are treated as keywords only in specific contexts (e.g., the keyword ```actions`
 | ```false```   |  ```header```   |  ```header_union``` | ```if```         |
 |  ```in```   | ```inout``` | ```int```         | ```match_kind``` |
 | ```package``` | ```parser``` | ```out```         | ```return```  |
-|```select``` | ```state``` | ```struct```   |  ```switch``` |
+| ```select``` | ```state``` | ```struct```   |  ```switch``` |
 | ```table```   | ```transition``` |  ```true``` |  ```tuple``` |
 | ```typedef``` | ```varbit```  | ```verify``` | ```void```       |
 |------|------|------|------|


### PR DESCRIPTION
Any spaces inside [#sec-label] causes Madoko not to convert it to a section number.