### PR TITLE
fix non-unicode characters

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4856,7 +4856,7 @@ tablePropertyList
 tableProperty
     : KEY '=' '{' keyElementList '}'
     | ACTIONS '=' '{' actionList '}'
-    | CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
+    | CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
     | optAnnotations CONST IDENTIFIER '=' initializer ';'
     | optAnnotations IDENTIFIER '=' initializer ';'
     ;
@@ -5093,14 +5093,14 @@ Table entries are defined using the following syntax:
 
 ~ Begin P4Grammar
 tableProperty
-   : const ENTRIES '=' '{' entriesList '}' /* immutable entries */
+ : const ENTRIES '=' '{' entriesLlist '}' /* immutable entries */
 
 entriesList
- : entry
- | entryList entry
+ : entry
+ | entryList entry
 
 entry
- : keysetExpression ':' actionRef optAnnotations ';'
+ : keysetExpression ':' actionRef optAnnotations ';'
 
 ~ End P4Grammar
 
@@ -6108,11 +6108,11 @@ same output.
 
 In contrast, `extern` blocks instantiated by a P4 program are
 global, shared across all threads. If `extern` blocks mediate
-access to state (e.g., counters, registers)–--i.e., the methods of
+access to state (e.g., counters, registers)---i.e., the methods of
 the `extern` block read and write state, these stateful operations
 are subject to data races. P4 mandates the following behaviors:
 
-- Execution of an action is atomic---i.e., the other threads can “see”
+- Execution of an action is atomic---i.e., the other threads can "see"
   the state as it is either before the start of the action or after
   the completion of the action.
 - Execution of a method call on an extern instance is atomic.


### PR DESCRIPTION
Fixing a few non-unicode characters in the spec that are caught by the python-markdown library.