### PR TITLE
Allow empty actions list

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4966,7 +4966,7 @@ the `actions` property; the value of this property is always an `actionList`:
 
 ~ Begin P4Grammar
 actionList
-    : actionRef ';'
+    : /* empty */
     | actionList actionRef ';'
     ;
 

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -460,7 +460,7 @@ keyElement
     ;
 
 actionList
-    : actionRef ';'
+    : /* empty */
     | actionList actionRef ';'
     ;
 


### PR DESCRIPTION
Because we don't require a default_action, and the compiler will (logically) insert a NoAction call in this case, it makes sense to allow tables to have an empty actions list.
