### PR TITLE
Replace `header` with `h` in Checksum example in Appendix

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6391,7 +6391,7 @@ IP checksum verification could be done in a parser as:
 
 ~ Begin P4Example
 ck16.clear();           // prepare checksum unit
-ck16.update(header.ipv4); // write header
+ck16.update(h.ipv4);    // write header
 verify(ck16.get() == 16w0, error.IPv4ChecksumError); // check for 0 checksum
 
 ~ End P4Example
@@ -6399,10 +6399,10 @@ verify(ck16.get() == 16w0, error.IPv4ChecksumError); // check for 0 checksum
 IP checksum generation could be done as:
 
 ~ Begin P4Example
-header.ipv4.hdrChecksum = 16w0;
+h.ipv4.hdrChecksum = 16w0;
 ck16.clear();
-ck16.update(header.ipv4);
-header.ipv4.hdrChecksum = ck16.get();
+ck16.update(h.ipv4);
+h.ipv4.hdrChecksum = ck16.get();
 ~ End P4Example
 
 Moreover, some switch architectures do not perform checksum
@@ -6412,11 +6412,11 @@ P4 program fragments illustrates:
 
 ~ Begin P4Example
 ck16.clear();
-ck16.update(header.ipv4.hdrChecksum);  // original checksum
-ck16.remove( { header.ipv4.ttl, header.ipv4.proto } );
-header.ipv4.ttl = header.ipv4.ttl - 1;
-ck16.update( { header.ipv4.ttl, header.ipv4.proto } );
-header.ipv4.hdrChecksum = ck16.get();
+ck16.update(h.ipv4.hdrChecksum);  // original checksum
+ck16.remove( { h.ipv4.ttl, h.ipv4.proto } );
+h.ipv4.ttl = h.ipv4.ttl - 1;
+ck16.update( { h.ipv4.ttl, h.ipv4.proto } );
+h.ipv4.hdrChecksum = ck16.get();
 ~ End P4Example
 
 # Appendix: Open Issues


### PR DESCRIPTION
Note that `header` is a reserved keyword!