### PR TITLE
Use Madoko file fragments to include code from separate psa.p4 file

### DIFF
--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -11,3 +11,8 @@ build/${SPEC}.pdf: psa.p4
 
 clean:
 	${RM} -rf build
+
+P4C=p4test
+
+check:
+	${P4C} examples/psa-example-counters.p4

--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -7,6 +7,7 @@ build/${SPEC}.pdf: ${SPEC}.mdk
 	madoko --pdf -vv --odir=build $<
 
 build/${SPEC}.pdf: p4.json
+build/${SPEC}.pdf: psa.p4
 
 clean:
 	${RM} -rf build

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -92,45 +92,13 @@ These types need to be defined before including the architecture file
 and the macro protecting them should be defined.
 
 ```
-typedef bit<unspecified> PortId_t;
-typedef bit<unspecified> MulticastGroup_t;
-typedef bit<unspecified> PacketLength_t;
-typedef bit<unspecified> EgressInstance_t;
-typedef bit<unspecified> ParserStatus_t;
-typedef bit<unspecified> ParserErrorLocation_t;
-typedef bit<unspecified> entry_key;           /// for DirectCounters
-
-const   PortId_t         PORT_CPU = unspecified;
-
+[INCLUDE=psa.p4:Type_defns]
 ```
 
 ## PSA supported metadata types
 
 ```
-enum InstanceType_t { NORMAL_INSTANCE, CLONE_INSTANCE }
-
-struct psa_parser_input_metadata_t {
-  PortId_t                 ingress_port;
-  InstanceType_t           instance_type;
-}
-
-struct psa_ingress_input_metadata_t {
-  PortId_t                 ingress_port;
-  InstanceType_t           instance_type;  /// Clone or Normal
-  /// set by the runtime in the parser, these are not under programmer control
-  ParserStatus_t           parser_status;
-  ParserErrorLocation_t    parser_error_location;
-}
-
-struct psa_ingress_output_metadata_t {
-  PortId_t                 egress_port;
-}
-
-struct psa_egress_input_metadata_t {
-  PortId_t                 egress_port;
-  InstanceType_t           instance_type;  /// Clone or Normal
-  EgressInstance_t         instance;       /// instance coming from PRE
-}
+[INCLUDE=psa.p4:Metadata_types]
 ```
 
 ## Match kinds
@@ -138,22 +106,13 @@ struct psa_egress_input_metadata_t {
 Additional supported match_kind types
 
 ```
-match_kind {
-    range,   /// Used to represent min..max intervals
-    selector /// Used for implementing dynamic_action_selection
-}
+[INCLUDE=psa.p4:Match_kinds]
 ```
 
 ## Cloning methods
 
 ```
-enum CloneMethod_t {
-  /// Clone method         Packet source             Insertion point
-  Ingress2Ingress,  /// original ingress,            Ingress parser
-  Ingress2Egress,    /// post parse original ingress,  Buffering queue
-  Egress2Ingress,   /// post deparse in egress,      Ingress parser
-  Egress2Egress     /// inout to deparser in egress, Buffering queue
-}
+[INCLUDE=psa.p4:Cloning_methods]
 ```
 
 # PSA Externs
@@ -446,16 +405,7 @@ void truncate(in bit<32> length);
 
 Supported hash algorithms:
 ```
-enum HashAlgorithm {
-  identity,
-  crc32,
-  crc32_custom,
-  crc16,
-  crc16_custom,
-  ones_complement16,  /// One's complement 16-bit sum used for IPv4 headers,
-                      /// TCP, and UDP.
-  random              /// are random hash algorithms useful?
-}
+[INCLUDE=psa.p4:Hash_algorithms]
 ```
 
 ### Hash function
@@ -475,24 +425,7 @@ Parameters:
 - O    The type of the return value of the hash.
 
 ```
-extern Hash<O> {
-  /// Constructor
-  Hash(HashAlgorithm algo);
-
-  /// Compute the hash for data.
-  /// @param data The data over which to calculate the hash.
-  /// @return The hash value.
-  O getHash<D>(in D data);
-
-  /// Compute the hash for data, with modulo by max, then add base.
-  /// @param base Minimum return value.
-  /// @param data The data over which to calculate the hash.
-  /// @param max The hash value is divided by max to get modulo.
-  ///        An implementation may limit the largest value supported,
-  ///        e.g. to a value like 32, or 256.
-  /// @return (base + (h % max)) where h is the hash value.
-  O getHash<T, D>(in T base, in D data, in T max);
-}
+[INCLUDE=psa.p4:Hash_extern]
 ```
 
 TBD: Should there be a `const` defined that specifies the maximum
@@ -512,13 +445,7 @@ Parameters:
 - W    The width of the checksum
 
 ```
-extern Checksum<W> {
-  Checksum(HashAlgorithm hash);          /// constructor
-  void clear();              /// prepare unit for computation
-  void update<T>(in T data); /// add data to checksum
-  void remove<T>(in T data); /// remove data from existing checksum
-  W    get();      	     /// get the checksum for data added since last clear
-}
+[INCLUDE=psa.p4:Checksum_extern]
 ```
 
 ## Counters
@@ -533,53 +460,19 @@ have an instance for each entry in the table.
 ### Counter types
 
 ```
-enum CounterType_t {
-    packets,
-    bytes,
-    packets_and_bytes
-}
+[INCLUDE=psa.p4:CounterType_defn]
 ```
 
 ### Counter
 
 ```
-extern Counter<W, S> {
-  Counter(S n_counters, W size_in_bits, CounterType_t counter_type);
-  void count(in S index, in W increment);
-
-  /*
-  @ControlPlaneAPI
-  {
-    W    read<W>      (in S index);
-    W    sync_read<W> (in S index);
-    void set          (in S index, in W seed);
-    void reset        (in S index);
-    void start        (in S index);
-    void stop         (in S index);
-  }
-  */
-}
+[INCLUDE=psa.p4:Counter_extern]
 ```
 
 ### Direct Counter
 
 ```
-extern DirectCounter<W> {
-  DirectCounter(CounterType_t counter_type);
-  void count();
-
-  /*
-  @ControlPlaneAPI
-  {
-    W    read<W>      (in entry_key key);
-    W    sync_read<W> (in entry_key key);
-    void set          (in W seed);
-    void reset        (in entry_key key);
-    void start        (in entry_key key);
-    void stop         (in entry_key key);
-  }
-  */
-}
+[INCLUDE=psa.p4:DirectCounter_extern]
 ```
 
 ## Meters
@@ -590,59 +483,27 @@ are 3-color meters.
 
 
 ### Meter types
+
 ```
-enum MeterType_t {
-    packets,
-    bytes
-}
+[INCLUDE=psa.p4:MeterType_defn]
 ```
 
 ### Meter colors
 
 ```
-enum MeterColor_t { RED, GREEN, YELLOW };
+[INCLUDE=psa.p4:MeterColor_defn]
 ```
 
 ### Meter
 
 ```
-extern Meter<S> {
-  Meter(S n_meters, MeterType_t type);
-  MeterColor_t execute(in S index, in MeterColor_t color);
-
-  /*
-  @ControlPlaneAPI
-  {
-    reset(in MeterColor_t color);
-    setParams(in S committedRate, in S committedBurstSize
-              in S peakRate, in S peakBurstSize);
-    getParams(out S committedRate, out S committedBurstSize
-              out S peakRate, out S peakBurstSize);
-  }
-  */
-}
+[INCLUDE=psa.p4:Meter_extern]
 ```
 
 ### Direct Meter
 
 ```
-extern DirectMeter {
-  DirectMeter(MeterType_t type);
-  MeterColor_t execute(in MeterColor_t color);
-
-  /*
-  @ControlPlaneAPI
-  {
-    reset(in entry_key entry, in MeterColor_t color);
-    void setParams<S>(in entry_key entry,
-                      in S committedRate, in S committedBurstSize
-                      in S peakRate, in S peakBurstSize);
-    void getParams<S>(in entry_key entry,
-                      out S committedRate, out S committedBurstSize
-                      out S peakRate, out S peakBurstSize);
-  }
-  */
-}
+[INCLUDE=psa.p4:DirectMeter_extern]
 ```
 
 ## Registers
@@ -667,20 +528,7 @@ marked as active.
 
 
 ```
-extern Register<T, S> {
-  Register(S size);
-  T    read  (in S index);
-  void write (in S index, in T value);
-
-  /*
-  @ControlPlaneAPI
-  {
-    T    read<T>      (in S index);
-    void set          (in S index, in T seed);
-    void reset        (in S index);
-  }
-  */
-}
+[INCLUDE=psa.p4:Register_extern]
 ```
 
 ## Random
@@ -694,26 +542,11 @@ The set of distributions supported by the Random extern.
 return whatever distribution is supported by the target?
 
 ```
-enum RandomDistribution {
-  PRNG,
-  Binomial,
-  Poisson
-}
+[INCLUDE=psa.p4:RandomDistribution_defn]
 ```
 
 ```
-extern Random<T> {
-  Random(RandomDistribution dist, T min, T max);
-  T read();
-
-  /*
-  @ControlPlaneAPI
-  {
-    void reset();
-    void setSeed(in T seed);
-  }
-  */
-}
+[INCLUDE=psa.p4:Random_extern]
 ```
 
 ## Action Profile
@@ -727,19 +560,7 @@ entries (members) into the extern, they are essentially populating
 the corresponding table entries.
 
 ```
-extern ActionProfile {
-  /// Construct an action profile of 'size' entries
-  ActionProfile(bit<32> size);
-
-  /*
-  @ControlPlaneAPI
-  {
-     entry_handle add_member    (action_ref, action_data);
-     void         delete_member (entry_handle);
-     entry_handle modify_member (entry_handle, action_ref, action_data);
-  }
-  */
-}
+[INCLUDE=psa.p4:ActionProfile_extern]
 ```
 
 ## Action Selector
@@ -756,26 +577,7 @@ instantiate this extern. When the control plane adds entries
 corresponding table entries.
 
 ```
-extern ActionSelector {
-  /// Construct an action selector of 'size' entries
-  /// @param algo hash algorithm to select a member in a group
-  /// @param size number of entries in the action selector
-  /// @param outputWidth size of the key
-  ActionSelector(HashAlgorithm algo, bit<32> size, bit<32> outputWidth);
-
-  /*
-  @ControlPlaneAPI
-  {
-     entry_handle add_member        (action_ref, action_data);
-     void         delete_member     (entry_handle);
-     entry_handle modify_member     (entry_handle, action_ref, action_data);
-     group_handle create_group      ();
-     void         delete_group      (group_handle);
-     void         add_to_group      (group_handle, entry_handle);
-     void         delete_from_group (group_handle, entry_handle);
-  }
-  */
-}
+[INCLUDE=psa.p4:ActionSelector_extern]
 ```
 
 ## Packet Generation
@@ -785,19 +587,7 @@ it adding a header to the current packet and sending it to the
 stream (copying or redirecting).
 
 ```
-extern Digest<T> {
-  Digest(PortId_t receiver); /// define a digest stream to receiver
-  void emit(in T data);      /// emit data into the stream
-
-  /*
-  @ControlPlaneAPI
-  {
-  // TBD
-  // If the type T is a named struct, the name should be used
-  // to generate the control-plane API.
-  }
-  */
-}
+[INCLUDE=psa.p4:Digest_extern]
 ```
 
 # Programmable blocks
@@ -816,28 +606,5 @@ matches the in parameter of the subsequent block.
 
 
 ```
-parser Parser<H, M>(packet_in buffer, out H parsed_hdr, inout M user_meta,
-                    in psa_parser_input_metadata_t istd);
-
-control VerifyChecksum<H, M>(in H hdr, inout M user_meta);
-
-control Ingress<H, M>(inout H hdr, inout M user_meta,
-                      PacketReplicationEngine pre,
-                      in  psa_ingress_input_metadata_t  istd,
-                      out psa_ingress_output_metadata_t ostd);
-
-control Egress<H, M>(inout H hdr, inout M user_meta,
-                     BufferingQueueingEngine bqe,
-                     in  psa_egress_input_metadata_t  istd);
-
-control ComputeChecksum<H, M>(inout H hdr, inout M user_meta);
-
-control Deparser<H>(packet_out buffer, in H hdr);
-
-package PSA_Switch<H, M>(Parser<H, M> p,
-                         VerifyChecksum<H, M> vr,
-                         Ingress<H, M> ig,
-                         Egress<H, M> eg,
-                         ComputeChecksum<H, M> ck,
-                         Deparser<H> dep);
+[INCLUDE=psa.p4:Programmable_blocks]
 ```

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -1,0 +1,165 @@
+/*
+Copyright 2017 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "../psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+// BEGIN:Counter_Example_Part1
+#define BYTE_COUNT_SIZE 48
+typedef bit<48> ByteCounter_t;
+typedef bit<32> PacketCounter_t;
+typedef bit<80> PacketByteCounter_t;
+
+const PortId_t NUM_PORTS = 512;
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+}
+// END:Counter_Example_Part1
+
+parser ParserImpl(packet_in buffer,
+                  out headers parsed_hdr,
+                  inout metadata user_meta,
+                  in psa_parser_input_metadata_t istd)
+{
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+// BEGIN:Counter_Example_Part2
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                PacketReplicationEngine pre,
+                in  psa_ingress_input_metadata_t  istd,
+                out psa_ingress_output_metadata_t ostd)
+{
+    Counter<ByteCounter_t, PortId_t>(NUM_PORTS, BYTE_COUNT_SIZE,
+        CounterType_t.bytes) port_bytes_in;
+    DirectCounter<PacketByteCounter_t>(CounterType_t.packets_and_bytes)
+        per_prefix_pkt_byte_count;
+
+    action next_hop(PortId_t oport) {
+        per_prefix_pkt_byte_count.count();
+        ostd.egress_port = oport;
+    }
+    action default_route_drop() {
+        per_prefix_pkt_byte_count.count();
+        pre.drop();
+    }
+    table ipv4_da_lpm {
+        key = { hdr.ipv4.dstAddr: lpm; }
+        actions = {
+            next_hop;
+            default_route_drop;
+        }
+        default_action = default_route_drop;
+        //psa_direct_counters = {
+        //    per_prefix_pkt_byte_count;
+        //}
+    }
+    apply {
+        port_bytes_in.count(istd.ingress_port,
+                            (ByteCounter_t) hdr.ipv4.totalLen);
+        ostd.egress_port = 0;
+        if (hdr.ipv4.isValid()) {
+            ipv4_da_lpm.apply();
+        }
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               BufferingQueueingEngine bqe,
+               in  psa_egress_input_metadata_t  istd)
+{
+    Counter<ByteCounter_t, PortId_t>(NUM_PORTS, BYTE_COUNT_SIZE,
+        CounterType_t.bytes) port_bytes_out;
+    apply {
+        // By doing these stats updates on egress, as long as IP
+        // multicast replication happens in the packet buffer, this
+        // update will occur once for each copy made, which in this
+        // example is intentional.
+        port_bytes_out.count(istd.egress_port,
+                             (ByteCounter_t) hdr.ipv4.totalLen);
+    }
+}
+// END:Counter_Example_Part2
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control verifyChecksum(in headers hdr, inout metadata meta) {
+    apply { }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply { }
+}
+
+PSA_Switch(ParserImpl(),
+           verifyChecksum(),
+           ingress(),
+           egress(),
+           computeChecksum(),
+           DeparserImpl()) main;

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -1,0 +1,390 @@
+/*
+Copyright 2013-present Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#ifndef _PORTABLE_SWITCH_ARCHITECTURE_P4_
+#define _PORTABLE_SWITCH_ARCHITECTURE_P4_
+
+/**
+ *   P4-16 declaration of the Portable Switch Architecture
+ */
+
+/**
+ * These types need to be defined before including the architecture file
+ * and the macro protecting them should be defined.
+ */
+#define PSA_CORE_TYPES
+#ifdef PSA_CORE_TYPES
+typedef bit<10> PortId_t;
+typedef bit<10> MulticastGroup_t;
+typedef bit<14> PacketLength_t;
+typedef bit<16> EgressInstance_t;
+typedef bit<8> ParserStatus_t;
+typedef bit<16> ParserErrorLocation_t;
+typedef bit<32> entry_key;           /// for DirectCounters
+
+const   PortId_t         PORT_CPU = 255;
+
+// typedef bit<unspecified> InstanceType_t;
+// const   InstanceType_t   INSTANCE_NORMAL = unspecified;
+#endif  // PSA_CORE_TYPES
+#ifndef PSA_CORE_TYPES
+#error "Please define the following types for PSA and the PSA_CORE_TYPES macro"
+// BEGIN:Type_defns
+typedef bit<unspecified> PortId_t;
+typedef bit<unspecified> MulticastGroup_t;
+typedef bit<unspecified> PacketLength_t;
+typedef bit<unspecified> EgressInstance_t;
+typedef bit<unspecified> ParserStatus_t;
+typedef bit<unspecified> ParserErrorLocation_t;
+typedef bit<unspecified> entry_key;           /// for DirectCounters
+
+const   PortId_t         PORT_CPU = unspecified;
+// END:Type_defns
+
+// typedef bit<unspecified> InstanceType_t;
+// const   InstanceType_t   INSTANCE_NORMAL = unspecified;
+#endif
+
+// BEGIN:Metadata_types
+enum InstanceType_t { NORMAL_INSTANCE, CLONE_INSTANCE }
+
+struct psa_parser_input_metadata_t {
+  PortId_t                 ingress_port;
+  InstanceType_t           instance_type;
+}
+
+struct psa_ingress_input_metadata_t {
+  PortId_t                 ingress_port;
+  InstanceType_t           instance_type;  /// Clone or Normal
+  /// set by the runtime in the parser, these are not under programmer control
+  ParserStatus_t           parser_status;
+  ParserErrorLocation_t    parser_error_location;
+}
+
+struct psa_ingress_output_metadata_t {
+  PortId_t                 egress_port;
+}
+
+struct psa_egress_input_metadata_t {
+  PortId_t                 egress_port;
+  InstanceType_t           instance_type;  /// Clone or Normal
+  EgressInstance_t         instance;       /// instance coming from PRE
+}
+// END:Metadata_types
+
+// BEGIN:Match_kinds
+match_kind {
+    range,   /// Used to represent min..max intervals
+    selector /// Used for implementing dynamic_action_selection
+}
+// END:Match_kinds
+
+// BEGIN:Cloning_methods
+enum CloneMethod_t {
+  /// Clone method         Packet source             Insertion point
+  Ingress2Ingress,  /// original ingress,            Ingress parser
+  Ingress2Egress,    /// post parse original ingress,  Buffering queue
+  Egress2Ingress,   /// post deparse in egress,      Ingress parser
+  Egress2Egress     /// inout to deparser in egress, Buffering queue
+}
+// END:Cloning_methods
+
+extern PacketReplicationEngine {
+
+  // PacketReplicationEngine(); /// No constructor. PRE is instantiated
+                                /// by the architecture.
+    void send_to_port (in PortId_t port);
+    void multicast (in MulticastGroup_t multicast_group);
+    void drop      ();
+    void clone     (in CloneMethod_t clone_method, in PortId_t port);
+    void clone<T>  (in CloneMethod_t clone_method, in PortId_t port, in T data);
+    void resubmit<T>(in T data, in PortId_t port);
+    void recirculate<T>(in T data, in PortId_t port);
+    void truncate(in bit<32> length);
+}
+
+extern BufferingQueueingEngine {
+
+  // BufferingQueueingEngine(); /// No constructor. BQE is instantiated
+                                /// by the architecture.
+
+    void send_to_port (in PortId_t port);
+    void drop      ();
+    void truncate(in bit<32> length);
+}
+
+// BEGIN:Hash_algorithms
+enum HashAlgorithm {
+  identity,
+  crc32,
+  crc32_custom,
+  crc16,
+  crc16_custom,
+  ones_complement16,  /// One's complement 16-bit sum used for IPv4 headers,
+                      /// TCP, and UDP.
+  random              /// are random hash algorithms useful?
+}
+// END:Hash_algorithms
+
+// BEGIN:Hash_extern
+extern Hash<O> {
+  /// Constructor
+  Hash(HashAlgorithm algo);
+
+  /// Compute the hash for data.
+  /// @param data The data over which to calculate the hash.
+  /// @return The hash value.
+  O getHash<D>(in D data);
+
+  /// Compute the hash for data, with modulo by max, then add base.
+  /// @param base Minimum return value.
+  /// @param data The data over which to calculate the hash.
+  /// @param max The hash value is divided by max to get modulo.
+  ///        An implementation may limit the largest value supported,
+  ///        e.g. to a value like 32, or 256.
+  /// @return (base + (h % max)) where h is the hash value.
+  O getHash<T, D>(in T base, in D data, in T max);
+}
+// END:Hash_extern
+
+// BEGIN:Checksum_extern
+extern Checksum<W> {
+  Checksum(HashAlgorithm hash);          /// constructor
+  void clear();              /// prepare unit for computation
+  void update<T>(in T data); /// add data to checksum
+  void remove<T>(in T data); /// remove data from existing checksum
+  W    get();      	     /// get the checksum for data added since last clear
+}
+// END:Checksum_extern
+
+// BEGIN:CounterType_defn
+enum CounterType_t {
+    packets,
+    bytes,
+    packets_and_bytes
+}
+// END:CounterType_defn
+
+// BEGIN:Counter_extern
+extern Counter<W, S> {
+  Counter(S n_counters, W size_in_bits, CounterType_t counter_type);
+  void count(in S index, in W increment);
+
+  /*
+  @ControlPlaneAPI
+  {
+    W    read<W>      (in S index);
+    W    sync_read<W> (in S index);
+    void set          (in S index, in W seed);
+    void reset        (in S index);
+    void start        (in S index);
+    void stop         (in S index);
+  }
+  */
+}
+// END:Counter_extern
+
+// BEGIN:DirectCounter_extern
+extern DirectCounter<W> {
+  DirectCounter(CounterType_t counter_type);
+  void count();
+
+  /*
+  @ControlPlaneAPI
+  {
+    W    read<W>      (in entry_key key);
+    W    sync_read<W> (in entry_key key);
+    void set          (in W seed);
+    void reset        (in entry_key key);
+    void start        (in entry_key key);
+    void stop         (in entry_key key);
+  }
+  */
+}
+// END:DirectCounter_extern
+
+// BEGIN:MeterType_defn
+enum MeterType_t {
+    packets,
+    bytes
+}
+// END:MeterType_defn
+
+// BEGIN:MeterColor_defn
+enum MeterColor_t { RED, GREEN, YELLOW };
+// END:MeterColor_defn
+
+// BEGIN:Meter_extern
+extern Meter<S> {
+  Meter(S n_meters, MeterType_t type);
+  MeterColor_t execute(in S index, in MeterColor_t color);
+
+  /*
+  @ControlPlaneAPI
+  {
+    reset(in MeterColor_t color);
+    setParams(in S committedRate, in S committedBurstSize
+              in S peakRate, in S peakBurstSize);
+    getParams(out S committedRate, out S committedBurstSize
+              out S peakRate, out S peakBurstSize);
+  }
+  */
+}
+// END:Meter_extern
+
+// BEGIN:DirectMeter_extern
+extern DirectMeter {
+  DirectMeter(MeterType_t type);
+  MeterColor_t execute(in MeterColor_t color);
+
+  /*
+  @ControlPlaneAPI
+  {
+    reset(in entry_key entry, in MeterColor_t color);
+    void setParams<S>(in entry_key entry,
+                      in S committedRate, in S committedBurstSize
+                      in S peakRate, in S peakBurstSize);
+    void getParams<S>(in entry_key entry,
+                      out S committedRate, out S committedBurstSize
+                      out S peakRate, out S peakBurstSize);
+  }
+  */
+}
+// END:DirectMeter_extern
+
+// BEGIN:Register_extern
+extern Register<T, S> {
+  Register(S size);
+  T    read  (in S index);
+  void write (in S index, in T value);
+
+  /*
+  @ControlPlaneAPI
+  {
+    T    read<T>      (in S index);
+    void set          (in S index, in T seed);
+    void reset        (in S index);
+  }
+  */
+}
+// END:Register_extern
+
+// BEGIN:RandomDistribution_defn
+enum RandomDistribution {
+  PRNG,
+  Binomial,
+  Poisson
+}
+// END:RandomDistribution_defn
+
+// BEGIN:Random_extern
+extern Random<T> {
+  Random(RandomDistribution dist, T min, T max);
+  T read();
+
+  /*
+  @ControlPlaneAPI
+  {
+    void reset();
+    void setSeed(in T seed);
+  }
+  */
+}
+// END:Random_extern
+
+// BEGIN:ActionProfile_extern
+extern ActionProfile {
+  /// Construct an action profile of 'size' entries
+  ActionProfile(bit<32> size);
+
+  /*
+  @ControlPlaneAPI
+  {
+     entry_handle add_member    (action_ref, action_data);
+     void         delete_member (entry_handle);
+     entry_handle modify_member (entry_handle, action_ref, action_data);
+  }
+  */
+}
+// END:ActionProfile_extern
+
+// BEGIN:ActionSelector_extern
+extern ActionSelector {
+  /// Construct an action selector of 'size' entries
+  /// @param algo hash algorithm to select a member in a group
+  /// @param size number of entries in the action selector
+  /// @param outputWidth size of the key
+  ActionSelector(HashAlgorithm algo, bit<32> size, bit<32> outputWidth);
+
+  /*
+  @ControlPlaneAPI
+  {
+     entry_handle add_member        (action_ref, action_data);
+     void         delete_member     (entry_handle);
+     entry_handle modify_member     (entry_handle, action_ref, action_data);
+     group_handle create_group      ();
+     void         delete_group      (group_handle);
+     void         add_to_group      (group_handle, entry_handle);
+     void         delete_from_group (group_handle, entry_handle);
+  }
+  */
+}
+// END:ActionSelector_extern
+
+// BEGIN:Digest_extern
+extern Digest<T> {
+  Digest(PortId_t receiver); /// define a digest stream to receiver
+  void emit(in T data);      /// emit data into the stream
+
+  /*
+  @ControlPlaneAPI
+  {
+  // TBD
+  // If the type T is a named struct, the name should be used
+  // to generate the control-plane API.
+  }
+  */
+}
+// END:Digest_extern
+
+// BEGIN:Programmable_blocks
+parser Parser<H, M>(packet_in buffer, out H parsed_hdr, inout M user_meta,
+                    in psa_parser_input_metadata_t istd);
+
+control VerifyChecksum<H, M>(in H hdr, inout M user_meta);
+
+control Ingress<H, M>(inout H hdr, inout M user_meta,
+                      PacketReplicationEngine pre,
+                      in  psa_ingress_input_metadata_t  istd,
+                      out psa_ingress_output_metadata_t ostd);
+
+control Egress<H, M>(inout H hdr, inout M user_meta,
+                     BufferingQueueingEngine bqe,
+                     in  psa_egress_input_metadata_t  istd);
+
+control ComputeChecksum<H, M>(inout H hdr, inout M user_meta);
+
+control Deparser<H>(packet_out buffer, in H hdr);
+
+package PSA_Switch<H, M>(Parser<H, M> p,
+                         VerifyChecksum<H, M> vr,
+                         Ingress<H, M> ig,
+                         Egress<H, M> eg,
+                         ComputeChecksum<H, M> ck,
+                         Deparser<H> dep);
+// END:Programmable_blocks
+
+#endif  /* _PORTABLE_SWITCH_ARCHITECTURE_P4_ */


### PR DESCRIPTION
With this initial psa.p4 file, the resulting PSA document is the same
before and after this change.

This psa.p4 is not identical to the one in the p4lang/p4c repository.  That one has extra comments, and this one has some small fixes made to it in the p4-spec repository in the last couple of weeks.

This psa.p4 does compile when #include'd into a P4_16 program, without errors.