### PR TITLE
Some additions to description of meters.

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -716,7 +716,8 @@ must not use the undefined value in a way that affects the output
 packet or other side effects.  The example code below shows one way to
 achieve predictable behavior.  Note that this undefined behavior
 cannot occur if the value of `n_meters` of an indexed meter is $2^W$,
-and the type `S` used to construct the meter is `bit<W>`.
+and the type `S` used to construct the meter is `bit<W>`, since the
+index value could never be out of range.
 
 ```
 const int METER1_SIZE = 100;
@@ -749,8 +750,8 @@ Implementations will also have finite ranges and precisions that they
 support for the Peak Information Rate and Committed Information Rate.
 An implementation should document the maximum rates it support, as
 well as the precision it supports for implementing requested rates.
-It is recommended that the maximum rate supported be equal to the
-implementation' maximum speed port, and that the actual implemented
+It is recommended that the maximum rate supported be at least the rate
+of the implementation's fastest port, and that the actual implemented
 rate should always be within plus or minus 0.1% of the requested rate.
 
 ### Meter types

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -662,9 +662,9 @@ updating of `Counter` and `DirectCounter` externs.
 ## Meters
 
 Meters (RFC 2698) are a more complex mechanism for keeping statistics
-about the packets that trigger a table, most often used for dropping
+about packets, most often used for dropping
 or "marking" packets that exceed an average packet or bit rate.  To
-"mark" a packet means to change one or more of its quality of service
+mark a packet means to change one or more of its quality of service
 values in packet headers such as the 802.1Q PCP (priority code point)
 or DSCP (differentiated service code point) bits within the IPv4 or
 IPv6 type of service byte.  The meters specified in the PSA are
@@ -673,15 +673,24 @@ IPv6 type of service byte.  The meters specified in the PSA are
 PSA meters do not require any particular drop or marking actions, nor
 do they automatically implement those behaviors for you.  Meters keep
 enough state, and update their state during `execute()` method calls,
-in such a way that they return a green (also known as conform), yellow
-(exceed), or red (violate) result.  See RFC 2698 for details on the
+in such a way that they return a `GREEN` (also known as conform),
+`YELLOW` (exceed), or `RED` (violate) result.  See RFC 2698 for details on the
 conditions under which one of these three results is returned.  The P4
 program is responsible for examining that returned result, and making
 changes to packet forwarding behavior as a result.
 
+TBD: RFC 2698 specifies two options for 3-color meters: color blind
+and color aware.  If this specification is meant to allow either one,
+it should be documented how both are supported.  Otherwise, document
+which of the two options is the only one supported.  It might be true
+that color blind policers can be implemented via a color aware policer
+that one always passes `GREEN` to as the current packet color.
+
 Similar to counters, there are two flavors of meters: indexed and
 direct.  (Indexed) meters are addressed by index, while direct meters
-are addressed using P4Runtime table entry as key.
+always update a meter state corresponding to the matched table entry
+or action, and from the control plane API are addressed using
+P4Runtime table entry as key.
 
 There are many other similarities between counters and meters,
 including:
@@ -720,8 +729,8 @@ and the type `S` used to construct the meter is `bit<W>`, since the
 index value could never be out of range.
 
 ```
-const int METER1_SIZE = 100;
-Meter<bit<7>>((bit<32>) METER1_SIZE, MeterType_t.bytes) meter1;
+#define METER1_SIZE 100
+Meter<bit<7>>(METER1_SIZE, MeterType_t.bytes) meter1;
 bit<7> idx;
 MeterColor_t color1;
 
@@ -730,8 +739,8 @@ MeterColor_t color1;
 if (idx < METER1_SIZE) {
     color1 = meter1.execute(idx, MeterColor_t.GREEN);
 } else {
-    // If idx is out of range, use default value for color1.  One may
-    // also choose to store an error flag in some metadata field.
+    // If idx is out of range, use a default value for color1.  One
+    // may also choose to store an error flag in some metadata field.
     color1 = MeterColor_t.RED;
 }
 ```
@@ -748,7 +757,7 @@ milliseconds.
 
 Implementations will also have finite ranges and precisions that they
 support for the Peak Information Rate and Committed Information Rate.
-An implementation should document the maximum rates it support, as
+An implementation should document the maximum rate it supports, as
 well as the precision it supports for implementing requested rates.
 It is recommended that the maximum rate supported be at least the rate
 of the implementation's fastest port, and that the actual implemented

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -679,12 +679,10 @@ conditions under which one of these three results is returned.  The P4
 program is responsible for examining that returned result, and making
 changes to packet forwarding behavior as a result.
 
-TBD: RFC 2698 specifies two options for 3-color meters: color blind
-and color aware.  If this specification is meant to allow either one,
-it should be documented how both are supported.  Otherwise, document
-which of the two options is the only one supported.  It might be true
-that color blind policers can be implemented via a color aware policer
-that one always passes `GREEN` to as the current packet color.
+RFC 2698 describes "color aware" and "color blind" variations of
+meters.  The `Meter` and `DirectMeter` externs implement both.  The
+only difference is in which `execute` method you use when updating
+them.  See the comments on the `extern` definitions below.
 
 Similar to counters, there are two flavors of meters: indexed and
 direct.  (Indexed) meters are addressed by index, while direct meters

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -451,10 +451,8 @@ sequence numbers in packets, for example, use Registers instead
 
 Direct counters are counters associated with a particular P4 table,
 and are implemented by the extern `DirectCounter`.  There are also
-indirect counters, which are implemented by the extern `Counter` (the
-name 'indirect' does not imply that there is any indirection involved
-in the implementation, only that they are not direct counters).  The
-primary differences between direct counters and indirect counters are:
+indexed counters, which are implemented by the extern `Counter`.  The
+primary differences between direct counters and indexed counters are:
 
 - Number of independently updatable counter values:
   - A single instantiation of a direct counter always contains as many
@@ -462,14 +460,14 @@ primary differences between direct counters and indirect counters are:
     with which it is associated (TBD: see below for what this means
     for tables that use action profiles).
   - You must specify the number of independent counter values for an
-    indirect counter when instantiating it.  This number of counters
+    indexed counter when instantiating it.  This number of counters
     need not be the same as the size of any table.
 - Where counter updates are allowed in the P4 program:
   - For a direct counter, you may only invoke its `count` method from
     inside the actions of the table with which it is associated, and
     this always updates the counter value associated with the matching
     table entry.
-  - For an indirect counter, you may invoke its `count` method
+  - For an indexed counter, you may invoke its `count` method
     anywhere in the P4 program where extern object method invocations
     are permitted (e.g. inside actions, or directly inside a control's
     `apply` block), and every such invocation must specify the index
@@ -663,13 +661,82 @@ updating of `Counter` and `DirectCounter` externs.
 
 ## Meters
 
-Meters (RFC 2698) are a more complex mechanism for keeping statistics about
-the packets that trigger a table. The meters specified in the PSA
-are 3-color meters.
+Meters (RFC 2698) are a more complex mechanism for keeping statistics
+about the packets that trigger a table, most often used for dropping
+or "marking" packets that exceed an average packet or bit rate.  To
+"mark" a packet means to change one or more of its quality of service
+values in packet headers such as the 802.1Q PCP (priority code point)
+or DSCP (differentiated service code point) bits within the IPv4 or
+IPv6 type of service byte.  The meters specified in the PSA are
+3-color meters.
 
-Similar to counters, there are two flavors of meters: indirect and direct.
-(Indirect) meters are addressed by index, while direct meters are addressed
-using P4Runtime table entry as key.
+PSA meters do not require any particular drop or marking actions, nor
+do they automatically implement those behaviors for you.  Meters keep
+enough state, and update their state during `execute()` method calls,
+in such a way that they return a green (also known as conform), yellow
+(exceed), or red (violate) result.  See RFC 2698 for details on the
+conditions under which one of these three results is returned.  The P4
+program is responsible for examining that returned result, and making
+changes to packet forwarding behavior as a result.
+
+Similar to counters, there are two flavors of meters: indexed and
+direct.  (Indexed) meters are addressed by index, while direct meters
+are addressed using P4Runtime table entry as key.
+
+There are many other similarities between counters and meters,
+including:
+
+- The number of independently updatable meter values.
+- Where meter updates are allowed in a P4 program.
+- For `bytes` type meters, the packet length used in the update is
+  determined by the PSA implementation, and can vary from one PSA
+  implementation to another.
+
+As for counters, if you call the `execute(idx)` method on an indexed
+meter and `idx` is at least the number of meter states, so `idx` is
+out of range, no meter state is updated.  The `execute` call still
+returns a value of type `MeterColor_t`, but the value is undefined --
+programs that wish to have predictable behavior across implementations
+must not use the undefined value in a way that affects the output
+packet or other side effects.  The example code below shows one way to
+achieve predictable behavior.  Note that this undefined behavior
+cannot occur if the value of `n_meters` of an indexed meter is $2^W$,
+and the type `S` used to construct the meter is `bit<W>`.
+
+```
+const int METER1_SIZE = 100;
+Meter<bit<7>>((bit<32>) METER1_SIZE, MeterType_t.bytes) meter1;
+bit<7> idx;
+MeterColor_t color1;
+
+// ... later ...
+
+if (idx < METER1_SIZE) {
+    color1 = meter1.execute(idx, MeterColor_t.GREEN);
+} else {
+    // If idx is out of range, use default value for color1.  One may
+    // also choose to store an error flag in some metadata field.
+    color1 = MeterColor_t.RED;
+}
+```
+
+Any implementation will have a finite range that can be specified for
+the Peak Burst Size and Committed Burst Size.  An implementation
+should document the maximum burst sizes they support, and if the
+implementation internally truncates the values that the control plane
+requests to something more coarse than any number of bytes, that
+should also be documented.  It is recommended that the maximum burst
+sizes be allowed as large as the number of bytes that can be
+transmitted across the implementation's maximum speed port in 100
+milliseconds.
+
+Implementations will also have finite ranges and precisions that they
+support for the Peak Information Rate and Committed Information Rate.
+An implementation should document the maximum rates it support, as
+well as the precision it supports for implementing requested rates.
+It is recommended that the maximum rate supported be equal to the
+implementation' maximum speed port, and that the actual implemented
+rate should always be within plus or minus 0.1% of the requested rate.
 
 ### Meter types
 

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -692,6 +692,21 @@ including:
   determined by the PSA implementation, and can vary from one PSA
   implementation to another.
 
+Further similarities between direct counters and direct meters
+include:
+
+- `DirectMeter` `execute` method calls must be performed within
+  actions invoked by the table that owns the `DirectMeter` instance.
+  It is optional for such an action to call the `execute` method.
+- There must be a meter state associated with a `DirectMeter`
+  instance's owner table, that can be updated when the table result is
+  a miss.  As for a `DirectCounter`, this state only needs to exist if
+  a default action is assigned to the table.
+
+The table attribute to specify that a table owns a `DirectMeter`
+instance is `psa_direct_meters`.  The value of this table attribute is
+a list of meter instances.
+
 As for counters, if you call the `execute(idx)` method on an indexed
 meter and `idx` is at least the number of meter states, so `idx` is
 out of range, no meter state is updated.  The `execute` call still

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -243,8 +243,20 @@ enum MeterColor_t { RED, GREEN, YELLOW };
 // END:MeterColor_defn
 
 // BEGIN:Meter_extern
+// Indexed meter with n_meters independent meter states.
+
 extern Meter<S> {
-  Meter(S n_meters, MeterType_t type);
+  Meter(bit<32> n_meters, MeterType_t type);
+  // TBD: Either document why there is a 'color' parameter to the
+  // execute() method, and how it can cause the behavior to differ, or
+  // remove that parameter.  If it is there for operating in 'color
+  // aware' mode as described in RFC 2698, then there needs to be a
+  // way to specify either color aware or color blind operation when
+  // constructing meters, and it should be documented that the color
+  // parameter is ignored for color blind meters, or even better,
+  // there should be separate methods, one with the color parameter
+  // for color-aware meters, and another without for color-blind
+  // meters.
   MeterColor_t execute(in S index, in MeterColor_t color);
 
   /*
@@ -261,6 +273,7 @@ extern Meter<S> {
 // BEGIN:DirectMeter_extern
 extern DirectMeter {
   DirectMeter(MeterType_t type);
+  // TBD: Same comment as for direct Meter parameter 'color' above.
   MeterColor_t execute(in MeterColor_t color);
 
   /*

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -247,17 +247,16 @@ enum MeterColor_t { RED, GREEN, YELLOW };
 
 extern Meter<S> {
   Meter(bit<32> n_meters, MeterType_t type);
-  // TBD: Either document why there is a 'color' parameter to the
-  // execute() method, and how it can cause the behavior to differ, or
-  // remove that parameter.  If it is there for operating in 'color
-  // aware' mode as described in RFC 2698, then there needs to be a
-  // way to specify either color aware or color blind operation when
-  // constructing meters, and it should be documented that the color
-  // parameter is ignored for color blind meters, or even better,
-  // there should be separate methods, one with the color parameter
-  // for color-aware meters, and another without for color-blind
-  // meters.
+
+  // Use this method call to perform a color aware meter update (see
+  // RFC 2698). The color of the packet before the method call was
+  // made is specified by the color parameter.
   MeterColor_t execute(in S index, in MeterColor_t color);
+
+  // Use this method call to perform a color blind meter update (see
+  // RFC 2698).  It may be implemented via a call to execute(index,
+  // MeterColor_t.GREEN), which has the same behavior.
+  MeterColor_t execute(in S index);
 
   /*
   @ControlPlaneAPI
@@ -273,8 +272,9 @@ extern Meter<S> {
 // BEGIN:DirectMeter_extern
 extern DirectMeter {
   DirectMeter(MeterType_t type);
-  // TBD: Same comment as for direct Meter parameter 'color' above.
+  // See the corresponding methods for extern Meter.
   MeterColor_t execute(in MeterColor_t color);
+  MeterColor_t execute();
 
   /*
   @ControlPlaneAPI


### PR DESCRIPTION
This change also includes a proposed change of naming things "direct counters" and "indexed counters" (the latter name "indexed" in place of what has previously been called "indirect").  It isn't a big deal, and I can back out that part to go back to indirect if that is what people want.  I just wanted to propose the name "indexed", since it doesn't have any connotations of adding a level of indirection that the name "indirect" can.