### PR TITLE
Add table of contents to PSA spec

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -51,6 +51,8 @@ interface ports.
 
 ~ End Abstract
 
+[TOC]
+
 # Target Architecture Model
 
 


### PR DESCRIPTION
It is up to about 24 pages now, and a TOC can be nice for jumping to selected sections.