### PR TITLE
Proposed changes to CloneSpec_t

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -1162,7 +1162,7 @@ scaling[^DynamicFrequencyScaling].
 
 [^DynamicFrequencyScaling]: <https://en.wikipedia.org/wiki/Dynamic_frequency_scaling>
 
-Timestamps are of type `timestamp_t`, which is type `bit<W>` for a
+Timestamps are of type `Timestamp_t`, which is type `bit<W>` for a
 value of `W` defined by the implementation.  Timestamps are expected
 to wrap around during the normal passage of time.  It is recommended
 that an implementation pick a rate of advance and a bit width such
@@ -1227,7 +1227,7 @@ the P4Runtime API[^P4RuntimeAPI].
 // entity is read only.
 
 message TimestampInfo {
-  // The number of bits in the device's `timestamp_t` type.
+  // The number of bits in the device's `Timestamp_t` type.
   uint32 size_in_bits = 1;
   // The timestamp value of this device increments
   // `increments_per_period` times every `period_in_seconds` seconds.

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -90,8 +90,7 @@ corresponding to the programmable blocks are passed as arguments.
 
 ## PSA type definitions
 
-These types need to be defined before including the architecture file
-and the macro protecting them should be defined.
+These types need to be defined before including the architecture file.
 
 ```
 [INCLUDE=psa.p4:Type_defns]

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -81,6 +81,7 @@ struct psa_ingress_output_metadata_t {
   // The comment after each field specifies its initial value when the
   // Ingress control block begins executing.
   bool                     clone;            // false
+  CloneType_t              clone_type;       // undefined
   CloneSpec_t              clone_spec;       // undefined
   bool                     drop;             // true
   bool                     resubmit;         // false
@@ -101,6 +102,7 @@ struct psa_egress_output_metadata_t {
   // The comment after each field specifies its initial value when the
   // Egress control block begins executing.
   bool                     clone;         // false
+  CloneType_t              clone_type;    // undefined
   CloneSpec_t              clone_spec;    // undefined
   bool                     drop;          // false
   bool                     recirculate;   // false
@@ -118,12 +120,14 @@ match_kind {
 // END:Match_kinds
 
 // BEGIN:Cloning_methods
-enum CloneMethod_t {
-  /// Clone method         Packet source             Insertion point
-  Ingress2Ingress,  /// original ingress,            Ingress parser
-  Ingress2Egress,    /// post parse original ingress,  Buffering queue
-  Egress2Ingress,   /// post deparse in egress,      Ingress parser
-  Egress2Egress     /// inout to deparser in egress, Buffering queue
+enum CloneType_t {
+    ORIGINAL,   /// cloned packet contains the original header
+    MODIFIED    /// cloned packet contains the modified header
+}
+enum CloneSpec_t {
+    INGRESS,    /// cloned packet is sent to ingress packet buffer
+    EGRESS,     /// cloned packet is sent to queueing mechanism
+    CPU         /// TBD, should copy-to-cpu be part of CloneSpec_t?
 }
 // END:Cloning_methods
 

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -33,7 +33,7 @@ typedef bit<14> PacketLength_t;
 typedef bit<16> EgressInstance_t;
 typedef bit<8> ParserStatus_t;
 typedef bit<16> ParserErrorLocation_t;
-typedef bit<48> timestamp_t;
+typedef bit<48> Timestamp_t;
 typedef bit<16> CloneSpec_t;
 
 const   PortId_t         PORT_CPU = 255;
@@ -50,7 +50,7 @@ typedef bit<unspecified> PacketLength_t;
 typedef bit<unspecified> EgressInstance_t;
 typedef bit<unspecified> ParserStatus_t;
 typedef bit<unspecified> ParserErrorLocation_t;
-typedef bit<unspecified> timestamp_t;
+typedef bit<unspecified> Timestamp_t;
 typedef bit<unspecified> CloneSpec_t;
 
 const   PortId_t         PORT_CPU = unspecified;
@@ -74,7 +74,7 @@ struct psa_ingress_input_metadata_t {
   /// set by the runtime in the parser, these are not under programmer control
   ParserStatus_t           parser_status;
   ParserErrorLocation_t    parser_error_location;
-  timestamp_t              ingress_timestamp;
+  Timestamp_t              ingress_timestamp;
 }
 // BEGIN:Metadata_ingress_output
 struct psa_ingress_output_metadata_t {
@@ -94,7 +94,7 @@ struct psa_egress_input_metadata_t {
   PortId_t                 egress_port;
   InstanceType_t           instance_type;  /// Clone or Normal
   EgressInstance_t         instance;       /// instance coming from PRE
-  timestamp_t              egress_timestamp;
+  Timestamp_t              egress_timestamp;
 }
 // BEGIN:Metadata_egress_output
 struct psa_egress_output_metadata_t {


### PR DESCRIPTION
- Remove CloneMethod_t from psa.p4
- Added CloneType_t to specify if cloned packet is modified version or the original packet.
- Added CPU as a field to CloneSpec_t enum.