### PR TITLE
Small corrections, mostly to restore clean compilation of PSA example…

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -1,6 +1,6 @@
 Title : P4~16~ Portable Switch Architecture (PSA)
 Title Note : (draft)
-Title Footer: May 15, 2017
+Title Footer: August 23, 2017
 Author : The P4.org language consortium
 Heading depth: 4
 
@@ -90,7 +90,9 @@ corresponding to the programmable blocks are passed as arguments.
 
 ## PSA type definitions
 
-These types need to be defined before including the architecture file.
+Each PSA implementation will have specific bit widths for the
+following types.  These widths should be in that PSA implementation's
+custom `psa.p4` file.
 
 ```
 [INCLUDE=psa.p4:Type_defns]
@@ -298,7 +300,7 @@ Do not send a copy of the packet for normal egress processing.
 [INCLUDE=psa.p4:Action_ingress_drop]
 ```
 
-#### Truncate operation
+#### Truncate operation { #sec-ingress-truncate }
 
 For all copies of the packet made at the end of Ingress processing,
 truncate the payload to be at most the specified number of bytes.
@@ -498,7 +500,7 @@ complete.
 [INCLUDE=psa.p4:Action_egress_drop]
 ```
 
-#### Truncate operation
+#### Truncate operation { #sec-egress-truncate }
 
 For all copies of the packet made at the end of Egress processing,
 truncate the payload to be at most the specified number of bytes.

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -64,7 +64,8 @@ struct headers {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     state start {
         transition parse_ethernet;

--- a/p4-16/psa/examples/psa-example-register1.p4
+++ b/p4-16/psa/examples/psa-example-register1.p4
@@ -75,7 +75,8 @@ action update_pkt_ip_byte_count (inout PacketByteCountState_t s,
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     state start {
         transition parse_ethernet;

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -84,7 +84,8 @@ action update_pkt_ip_byte_count (inout PacketByteCountState_t s,
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     state start {
         transition parse_ethernet;

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -57,7 +57,8 @@ struct headers {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     ValueSet<bit<16>>(4) tpid_types;
     ValueSet<bit<16>>(2) trill_types;

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -56,7 +56,8 @@ struct headers {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     ValueSet<bit<16>>(4) tpid_types;
     ValueSet<bit<16>>(2) trill_types;

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -62,7 +62,8 @@ struct CustomValueSet1_t {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     ValueSet<CustomValueSet1_t>(2) trill_types;
 

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -40,6 +40,7 @@ typedef bit<16> EgressInstance_t;
 typedef bit<8> ParserStatus_t;
 typedef bit<16> ParserErrorLocation_t;
 typedef bit<48> Timestamp_t;
+typedef error   ParserError_t;
 
 const   PortId_t         PORT_CPU = 255;
 

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -34,8 +34,6 @@ typedef bit<16> EgressInstance_t;
 typedef bit<8> ParserStatus_t;
 typedef bit<16> ParserErrorLocation_t;
 typedef bit<48> Timestamp_t;
-typedef bit<16> CloneSpec_t;
-typedef error   ParserError_t;
 
 const   PortId_t         PORT_CPU = 255;
 
@@ -52,7 +50,6 @@ typedef bit<unspecified> EgressInstance_t;
 typedef bit<unspecified> ParserStatus_t;
 typedef bit<unspecified> ParserErrorLocation_t;
 typedef bit<unspecified> Timestamp_t;
-typedef bit<unspecified> CloneSpec_t;
 
 
 
@@ -88,7 +85,8 @@ struct psa_ingress_output_metadata_t {
   // Ingress control block begins executing.
   bool                     clone;            // false
   CloneType_t              clone_type;       // undefined
-  CloneSpec_t              clone_spec;       // undefined
+  CloneMethod_t            clone_method;     // undefined
+  PortId_t                 clone_port;       // undefined
   bool                     drop;             // true
   bool                     resubmit;         // false
   MulticastGroup_t         multicast_group;  // 0
@@ -110,7 +108,8 @@ struct psa_egress_output_metadata_t {
   // Egress control block begins executing.
   bool                     clone;         // false
   CloneType_t              clone_type;    // undefined
-  CloneSpec_t              clone_spec;    // undefined
+  CloneMethod_t            clone_method;  // undefined
+  PortId_t                 clone_port;    // undefined
   bool                     drop;          // false
   bool                     recirculate;   // false
   bool                     truncate;      // false
@@ -131,10 +130,10 @@ enum CloneType_t {
     ORIGINAL,   /// cloned packet contains the original header
     MODIFIED    /// cloned packet contains the modified header
 }
-enum CloneSpec_t {
+enum CloneMethod_t {
     INGRESS,    /// cloned packet is sent to ingress packet buffer
     EGRESS,     /// cloned packet is sent to queueing mechanism
-    CPU         /// TBD, should copy-to-cpu be part of CloneSpec_t?
+    CPU         /// TBD, should copy-to-cpu be part of CloneMethod_t?
 }
 // END:Cloning_methods
 

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -27,6 +27,12 @@ limitations under the License.
  */
 #define PSA_CORE_TYPES
 #ifdef PSA_CORE_TYPES
+/* The bit widths shown below are only examples.  Each PSA
+ * implementation is free to use its own custom width in bits for
+ * those types that are bit<W> for some W.  The only reason that there
+ * are example numerical widths in this file is so that we can easily
+ * compile this file, and example PSA P4 programs that include it. */
+
 typedef bit<10> PortId_t;
 typedef bit<10> MulticastGroup_t;
 typedef bit<14> PacketLength_t;
@@ -51,8 +57,6 @@ typedef bit<unspecified> ParserStatus_t;
 typedef bit<unspecified> ParserErrorLocation_t;
 typedef bit<unspecified> Timestamp_t;
 
-
-
 const   PortId_t         PORT_CPU = unspecified;
 // END:Type_defns
 
@@ -60,8 +64,25 @@ const   PortId_t         PORT_CPU = unspecified;
 // const   InstanceType_t   INSTANCE_NORMAL = unspecified;
 #endif
 
+// BEGIN:Cloning_methods
+enum CloneType_t {
+    ORIGINAL,   /// cloned packet contains the original header
+    MODIFIED    /// cloned packet contains the modified header
+}
+enum CloneSpec_t {
+    INGRESS,    /// cloned packet is sent to ingress packet buffer
+    EGRESS,     /// cloned packet is sent to queueing mechanism
+    CPU         /// TBD, should copy-to-cpu be part of CloneSpec_t?
+}
+// END:Cloning_methods
+
 // BEGIN:Metadata_types
-enum InstanceType_t { NORMAL, CLONE, RESUBMIT, RECIRCULATE }
+enum InstanceType_t {
+    NORMAL,     /// Packet is "normal", i.e. none of the other cases below
+    CLONE,      /// Packet was created via a clone operation
+    RESUBMIT,   /// Packet arrival is the result of a resubmit operation
+    RECIRCULATE /// Packet arrival is the result of a recirculate operation
+}
 
 struct psa_parser_input_metadata_t {
   PortId_t                 ingress_port;
@@ -73,9 +94,10 @@ struct psa_parser_output_metadata_t {
 }
 
 struct psa_ingress_input_metadata_t {
+  // All of these values are initialized by the architecture before
+  // the Ingress control block begins executing.
   PortId_t                 ingress_port;
-  InstanceType_t           instance_type;  /// Clone or Normal
-  /// set by the runtime in the parser, these are not under programmer
+  InstanceType_t           instance_type;
   Timestamp_t              ingress_timestamp;
   ParserError_t            parser_error;
 }
@@ -97,7 +119,7 @@ struct psa_ingress_output_metadata_t {
 // END:Metadata_ingress_output
 struct psa_egress_input_metadata_t {
   PortId_t                 egress_port;
-  InstanceType_t           instance_type;  /// Clone or Normal
+  InstanceType_t           instance_type;
   EgressInstance_t         instance;       /// instance coming from PRE
   Timestamp_t              egress_timestamp;
   ParserError_t            parser_error;
@@ -124,18 +146,6 @@ match_kind {
     selector /// Used for implementing dynamic_action_selection
 }
 // END:Match_kinds
-
-// BEGIN:Cloning_methods
-enum CloneType_t {
-    ORIGINAL,   /// cloned packet contains the original header
-    MODIFIED    /// cloned packet contains the modified header
-}
-enum CloneMethod_t {
-    INGRESS,    /// cloned packet is sent to ingress packet buffer
-    EGRESS,     /// cloned packet is sent to queueing mechanism
-    CPU         /// TBD, should copy-to-cpu be part of CloneMethod_t?
-}
-// END:Cloning_methods
 
 // BEGIN:Action_send_to_port
 /// Modify ingress output metadata to cause one packet to be sent to

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -69,10 +69,10 @@ enum CloneType_t {
     ORIGINAL,   /// cloned packet contains the original header
     MODIFIED    /// cloned packet contains the modified header
 }
-enum CloneSpec_t {
+enum CloneMethod_t {
     INGRESS,    /// cloned packet is sent to ingress packet buffer
     EGRESS,     /// cloned packet is sent to queueing mechanism
-    CPU         /// TBD, should copy-to-cpu be part of CloneSpec_t?
+    CPU         /// TBD, should copy-to-cpu be part of CloneMethod_t?
 }
 // END:Cloning_methods
 


### PR DESCRIPTION
… code

In psa.p4:

+ Remove redundant CloneSpec_t typedef.
+ Move new CloneType_t and CloneSpec_t declarations earlier, before
  they are used.
+ Add comments for each of the 4 possible values of InstanceType_t
+ Remove obsolete comments after fields with type InstanceType_t.
+ Add comments before typedef's with example bit widths, explaining
  that those widths are merely examples.

Update date of PSA draft.