### PR TITLE
Small corrections, mostly to restore clean compilation of PSA example…

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -1,6 +1,6 @@
 Title : P4~16~ Portable Switch Architecture (PSA)
 Title Note : (draft)
-Title Footer: May 15, 2017
+Title Footer: August 23, 2017
 Author : The P4.org language consortium
 Heading depth: 4
 
@@ -90,7 +90,9 @@ corresponding to the programmable blocks are passed as arguments.
 
 ## PSA type definitions
 
-These types need to be defined before including the architecture file.
+Each PSA implementation will have specific bit widths for the
+following types.  These widths should be in that PSA implementation's
+custom `psa.p4` file.
 
 ```
 [INCLUDE=psa.p4:Type_defns]
@@ -298,7 +300,7 @@ Do not send a copy of the packet for normal egress processing.
 [INCLUDE=psa.p4:Action_ingress_drop]
 ```
 
-#### Truncate operation
+#### Truncate operation { #sec-ingress-truncate }
 
 For all copies of the packet made at the end of Ingress processing,
 truncate the payload to be at most the specified number of bytes.
@@ -498,7 +500,7 @@ complete.
 [INCLUDE=psa.p4:Action_egress_drop]
 ```
 
-#### Truncate operation
+#### Truncate operation { #sec-egress-truncate }
 
 For all copies of the packet made at the end of Egress processing,
 truncate the payload to be at most the specified number of bytes.

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -64,7 +64,8 @@ struct headers {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     state start {
         transition parse_ethernet;

--- a/p4-16/psa/examples/psa-example-register1.p4
+++ b/p4-16/psa/examples/psa-example-register1.p4
@@ -75,7 +75,8 @@ action update_pkt_ip_byte_count (inout PacketByteCountState_t s,
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     state start {
         transition parse_ethernet;

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -84,7 +84,8 @@ action update_pkt_ip_byte_count (inout PacketByteCountState_t s,
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     state start {
         transition parse_ethernet;

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -57,7 +57,8 @@ struct headers {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     ValueSet<bit<16>>(4) tpid_types;
     ValueSet<bit<16>>(2) trill_types;

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -56,7 +56,8 @@ struct headers {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     ValueSet<bit<16>>(4) tpid_types;
     ValueSet<bit<16>>(2) trill_types;

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -62,7 +62,8 @@ struct CustomValueSet1_t {
 parser ParserImpl(packet_in buffer,
                   out headers parsed_hdr,
                   inout metadata user_meta,
-                  in psa_parser_input_metadata_t istd)
+                  in psa_parser_input_metadata_t istd,
+                  out psa_parser_output_metadata_t ostd)
 {
     ValueSet<CustomValueSet1_t>(2) trill_types;
 


### PR DESCRIPTION
… code

In psa.p4:

+ Remove redundant CloneSpec_t typedef.
+ Move new CloneType_t and CloneSpec_t declarations earlier, before
  they are used.
+ Add comments for each of the 4 possible values of InstanceType_t
+ Remove obsolete comments after fields with type InstanceType_t.
+ Add comments before typedef's with example bit widths, explaining
  that those widths are merely examples.

Update date of PSA draft.