### PR TITLE
Add example of using Checksum extern to detect wrong IPv4 header chec…

### DIFF
--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -20,3 +20,4 @@ check:
 	${P4C} examples/psa-example-value-sets2.p4
 	${P4C} examples/psa-example-value-sets3.p4
 	${P4C} examples/psa-example-register2.p4
+	${P4C} examples/psa-example-parser-checksum.p4

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -567,8 +567,8 @@ IPv4 header is correct, and set a parser error if it is wrong.  It
 also demonstrates checking for parser errors in the ingress control
 block, dropping the packet if any errors occurred during parsing.  PSA
 programs may choose to handle packets with parser errors in other ways
-than demonstrates in this example -- it is up to the P4 program author
-to choose and program the desired behavior.
+than shown in this example -- it is up to the P4 program author to
+choose and write the desired behavior.
 
 ```
 [INCLUDE=examples/psa-example-parser-checksum.p4:Parse_Error_Example]

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -574,6 +574,17 @@ choose and write the desired behavior.
 [INCLUDE=examples/psa-example-parser-checksum.p4:Parse_Error_Example]
 ```
 
+The partial program below demonstrates one way to use the `Checksum`
+extern to calculate and then fill in a correct IPv4 header checksum in
+the `computeChecksum` control block, just before the deparser.  A P4
+program that could parse multiple such headers (e.g. an outer and
+inner IPv4 header, for some kinds of IP tunneled packets) could repeat
+this for each such IPv4 header.
+
+```
+[INCLUDE=examples/psa-example-parser-checksum.p4:Compute_New_IPv4_Checksum_Example]
+```
+
 
 ## Counters
 

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -576,10 +576,11 @@ choose and write the desired behavior.
 
 The partial program below demonstrates one way to use the `Checksum`
 extern to calculate and then fill in a correct IPv4 header checksum in
-the `computeChecksum` control block, just before the deparser.  A P4
-program that could parse multiple such headers (e.g. an outer and
-inner IPv4 header, for some kinds of IP tunneled packets) could repeat
-this for each such IPv4 header.
+the `computeChecksum` control block, just before the deparser.  In
+this example, the checksum is calculated fresh, so the outgoing
+checksum will be correct regardless of what changes might have been
+made to the IPv4 header fields in the ingress (or egress) control
+block that precedes it.
 
 ```
 [INCLUDE=examples/psa-example-parser-checksum.p4:Compute_New_IPv4_Checksum_Example]

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -559,6 +559,22 @@ Parameters:
 [INCLUDE=psa.p4:Checksum_extern]
 ```
 
+### Checksum example
+
+The partial P4 program below demonstrates one way to use the
+`Checksum` extern to verify whether the checksum field in a parsed
+IPv4 header is correct, and set a parser error if it is wrong.  It
+also demonstrates checking for parser errors in the ingress control
+block, dropping the packet if any errors occurred during parsing.  PSA
+programs may choose to handle packets with parser errors in other ways
+than demonstrates in this example -- it is up to the P4 program author
+to choose and program the desired behavior.
+
+```
+[INCLUDE=examples/psa-example-parser-checksum.p4:Parse_Error_Example]
+```
+
+
 ## Counters
 
 Counters are a mechanism for keeping statistics.  The control plane

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -136,10 +136,12 @@ control ingress(inout headers hdr,
             default_route_drop;
         }
         default_action = default_route_drop;
-        //psa_direct_counters = {
-        //    // table ipv4_da_lpm owns this DirectCounter instance
-        //    per_prefix_pkt_byte_count;
-        //}
+#ifdef P4C_HANDLES_DIRECT_COUNTERS_TABLE_PROPERTY
+        psa_direct_counters = {
+            // table ipv4_da_lpm owns this DirectCounter instance
+            per_prefix_pkt_byte_count;
+        }
+#endif
     }
     apply {
         port_bytes_in.count(istd.ingress_port);

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -1,0 +1,232 @@
+/*
+Copyright 2017 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "../psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct fwd_metadata_t {
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+// BEGIN:Parse_Error_Example
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+typedef bit<32> PacketCounter_t;
+typedef bit<8>  ErrorIndex_t;
+
+const bit<9> NUM_ERRORS = 256;
+
+// Action convert_error_to_idx returns a unique ErrorIndex_t value (a
+// bit vector) for each possible value of the error type.  The error
+// type cannot be directly put into packet headers or used as an index
+// into counter, meter, or register arrays, so such a conversion
+// 'function' is necessary to get a value that can be used for these
+// purposes.
+
+action convert_error_to_idx (in ParserError_t err,
+                             out ErrorIndex_t idx)
+{
+    if (err == error.NoError) {
+        idx = 1;
+    } else if (err == error.PacketTooShort) {
+        idx = 2;
+    } else if (err == error.NoMatch) {
+        idx = 3;
+    } else if (err == error.StackOutOfBounds) {
+        idx = 4;
+    } else if (err == error.HeaderTooShort) {
+        idx = 5;
+    } else if (err == error.ParserTimeout) {
+        idx = 6;
+    } else if (err == error.BadIPv4HeaderChecksum) {
+        idx = 7;
+    } else if (err == error.UnhandledIPv4Options) {
+        idx = 8;
+    } else {
+        // Unknown error value
+        idx = 0;
+    }
+}
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         out psa_parser_output_metadata_t ostd)
+{
+    Checksum<bit<16>>(HashAlgorithm.ones_complement16) ck;
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        // TBD: It would be good to enhance this example to
+        // demonstrate checking of IPv4 header checksums for IPv4
+        // headers with options, but this example does not handle such
+        // packets.
+        verify(parsed_hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        // TBD: Update the code below for checking the IPv4 header
+        // checksum with whatever the API we decide upon for a PSA
+        // checksum extern.
+        ck.clear();
+        ck.update({ parsed_hdr.ipv4.version,
+                parsed_hdr.ipv4.ihl,
+                parsed_hdr.ipv4.diffserv,
+                parsed_hdr.ipv4.totalLen,
+                parsed_hdr.ipv4.identification,
+                parsed_hdr.ipv4.flags,
+                parsed_hdr.ipv4.fragOffset,
+                parsed_hdr.ipv4.ttl,
+                parsed_hdr.ipv4.protocol,
+                parsed_hdr.ipv4.hdrChecksum,
+                parsed_hdr.ipv4.srcAddr,
+                parsed_hdr.ipv4.dstAddr });
+        // The verify statement below will cause the parser to enter
+        // the reject state, and thus terminate parsing immediately,
+        // if the IPv4 header checksum is wrong.  It will also record
+        // the error error.BadIPv4HeaderChecksum, which will be
+        // available in a metadata field in the ingress control block.
+        verify(ck.get() == 0, error.BadIPv4HeaderChecksum);
+        transition select(parsed_hdr.ipv4.protocol) {
+            6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                PacketReplicationEngine pre,
+                in  psa_ingress_input_metadata_t  istd,
+                out psa_ingress_output_metadata_t ostd)
+{
+    Counter<PacketCounter_t, ErrorIndex_t>
+        ((bit<32>) NUM_ERRORS, CounterType_t.packets) parser_error_counts;
+    apply {
+        if (istd.parser_error != error.NoError) {
+            // Example code showing how to count number of times each
+            // kind of parser error was seen.
+            ErrorIndex_t error_idx;
+            convert_error_to_idx(istd.parser_error, error_idx);
+            parser_error_counts.count(error_idx);
+            ingress_drop(ostd);
+            exit;
+        }
+        // Do normal packet processing here.
+    }
+}
+// END:Parse_Error_Example
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        out psa_parser_output_metadata_t ostd)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               BufferingQueueingEngine bqe,
+               in  psa_egress_input_metadata_t  istd,
+               out psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+control computeChecksum(inout headers hdr, inout metadata meta) {
+    apply { }
+}
+
+control DeparserImpl(packet_out packet, in headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+PSA_Switch(IngressParserImpl(),
+           ingress(),
+           computeChecksum(),
+           DeparserImpl(),
+           EgressParserImpl(),
+           egress(),
+           computeChecksum(),
+           DeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -176,6 +176,9 @@ control ingress(inout headers hdr,
             error.BadIPv4HeaderChecksum : set_error_idx(7);
             error.UnhandledIPv4Options  : set_error_idx(8);
         }
+#ifdef P4C_HANDLES_DIRECT_COUNTERS_TABLE_PROPERTY
+        psa_direct_counters = { parser_error_counts; }
+#endif
     }
     apply {
         if (istd.parser_error != error.NoError) {

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -213,9 +213,30 @@ control egress(inout headers hdr,
     apply { }
 }
 
+// BEGIN:Compute_New_IPv4_Checksum_Example
 control computeChecksum(inout headers hdr, inout metadata meta) {
-    apply { }
+    Checksum<bit<16>>(HashAlgorithm.ones_complement16) ck;
+    apply {
+        // TBD: Update the code below for checking the IPv4 header
+        // checksum with whatever the API we decide upon for a PSA
+        // checksum extern.
+        ck.clear();
+        ck.update({ hdr.ipv4.version,
+                hdr.ipv4.ihl,
+                hdr.ipv4.diffserv,
+                hdr.ipv4.totalLen,
+                hdr.ipv4.identification,
+                hdr.ipv4.flags,
+                hdr.ipv4.fragOffset,
+                hdr.ipv4.ttl,
+                hdr.ipv4.protocol,
+                //hdr.ipv4.hdrChecksum, // intentionally leave this out
+                hdr.ipv4.srcAddr,
+                hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck.get();
+    }
 }
+// END:Compute_New_IPv4_Checksum_Example
 
 control DeparserImpl(packet_out packet, in headers hdr) {
     apply {

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -148,7 +148,7 @@ parser IngressParserImpl(packet_in buffer,
                 parsed_hdr.ipv4.fragOffset,
                 parsed_hdr.ipv4.ttl,
                 parsed_hdr.ipv4.protocol,
-                parsed_hdr.ipv4.hdrChecksum,
+                //parsed_hdr.ipv4.hdrChecksum, // intentionally leave this out
                 parsed_hdr.ipv4.srcAddr,
                 parsed_hdr.ipv4.dstAddr });
         // The verify statement below will cause the parser to enter
@@ -156,7 +156,8 @@ parser IngressParserImpl(packet_in buffer,
         // if the IPv4 header checksum is wrong.  It will also record
         // the error error.BadIPv4HeaderChecksum, which will be
         // available in a metadata field in the ingress control block.
-        verify(ck.get() == 0, error.BadIPv4HeaderChecksum);
+        verify(ck.get() == parsed_hdr.ipv4.hdrChecksum,
+               error.BadIPv4HeaderChecksum);
         transition select(parsed_hdr.ipv4.protocol) {
             6: parse_tcp;
             default: accept;

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -37,7 +37,6 @@ typedef bit<10> PortId_t;
 typedef bit<10> MulticastGroup_t;
 typedef bit<14> PacketLength_t;
 typedef bit<16> EgressInstance_t;
-typedef bit<8> ParserStatus_t;
 typedef bit<16> ParserErrorLocation_t;
 typedef bit<48> Timestamp_t;
 typedef error   ParserError_t;
@@ -54,7 +53,6 @@ typedef bit<unspecified> PortId_t;
 typedef bit<unspecified> MulticastGroup_t;
 typedef bit<unspecified> PacketLength_t;
 typedef bit<unspecified> EgressInstance_t;
-typedef bit<unspecified> ParserStatus_t;
 typedef bit<unspecified> ParserErrorLocation_t;
 typedef bit<unspecified> Timestamp_t;
 


### PR DESCRIPTION
…ksum

The same example also demonstrates:

+ How to use the parser error that is passed into the Ingress control
  block.
+ Example action that converts the 'error' type to a bit vector, so
  the resulting bit vector can be used for other purposes, e.g. an
  index into a Counter array.