### PR TITLE
Checksums

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -661,10 +661,6 @@ can be used to remove data previously added. It is based on the
 used to compute for protocols such as IPv4, TCP, and UDP -- see [IETF
 RFC 1624](https://tools.ietf.org/html/rfc1624) for details.
 
-Parameters:
-
-- W   The width of the checksum
-
 ```
 [INCLUDE=psa.p4:InternetChecksum_extern]    
 ```            

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -636,16 +636,17 @@ TBD: Should there be a `const` defined that specifies the maximum
 allowed value of `max` parameter?
 
 
-## Checksums
+## Checksums { #sec-checksums }
 
-Checksums operate on a stream of bytes from a packet to produce an
-integer that is often used as an integrity check.
+PSA provides checksum functions compute an integer on the stream of
+bytes in packet headers. Checksums are often used as an integrity
+check to detect corrupted or otherwise malformed packets.
 
-### Basic checksum
+### Basic checksum { #sec-basic-checksum }
 
 The basic checksum extern provided in PSA supports arbitrary hash
 algorithms.
-        
+
 Parameters:
 
 - W    The width of the checksum
@@ -654,29 +655,28 @@ Parameters:
 [INCLUDE=psa.p4:Checksum_extern]
 ```
 
-### Incremental checksum 
+### Incremental checksum { #sec-incremental-checksum }
 
-In addition, PSA provides an incremental checksum that comes equipped
-with an additional `remove` method that can be used to remove data
-previously added. The checksum is computed using the
-`ONES_COMPLEMENT16` hash algorithm used with protocols such as IPv4,
-TCP, and UDP -- see [IETF RFC 1624](https://tools.ietf.org/html/rfc1624)
-for details.
+PSA also provides an incremental checksum that comes equipped with an
+additional `remove` method that can be used to remove data previously
+added. The checksum is computed using the `ONES_COMPLEMENT16` hash
+algorithm used with protocols such as IPv4, TCP, and UDP -- see [IETF
+RFC 1624](https://tools.ietf.org/html/rfc1624) for details.
 
 ```
 [INCLUDE=psa.p4:InternetChecksum_extern]    
 ```            
     
-### Checksum example
+### Checksum examples { #sec-checksum-examples }
 
-The partial P4 program below demonstrates one way to use the
-`Checksum` extern to verify whether the checksum field in a parsed
-IPv4 header is correct, and set a parser error if it is wrong.  It
-also demonstrates checking for parser errors in the `ingress` control
-block, dropping the packet if any errors occurred during parsing.  PSA
-programs may choose to handle packets with parser errors in other ways
-than shown in this example -- it is up to the P4 program author to
-choose and write the desired behavior.
+The partial program below demonstrates one way to use the `Checksum`
+extern to verify whether the checksum field in a parsed IPv4 header is
+correct, and set a parser error if it is wrong.  It also demonstrates
+checking for parser errors in the `ingress` control block, dropping
+the packet if any errors occurred during parsing.  PSA programs may
+choose to handle packets with parser errors in other ways than shown
+in this example -- it is up to the P4 program author to choose and
+write the desired behavior.
 
 Neither P4~16~ nor the PSA provide any special mechanisms to record
 the location within a packet that a parser error occurred. A P4
@@ -701,18 +701,23 @@ changes might have been made to the IPv4 header fields in the ingress
 [INCLUDE=examples/psa-example-parser-checksum.p4:Compute_New_IPv4_Checksum_Example]
 ```
 
-TBD: It would be good if the Checksum extern can handle a case of
-doing a 'delta' correction of a TCP header checksum when an IPv4 or
-IPv6 source or destination address is changed, e.g. due to
-implementing a feature like NAT.  This should be possible without
-having to redo the TCP checksum over the entire TCP payload, by
-assuming that the incoming TCP header checksum was correct.  With the
-proposed `remove` and `update` methods, this should be possible by
-calling `remove` on the old source/destination addresses, and then
-`update` on the new source/destination addresses.  It would also be
-good to have a short example program demonstrating one way to do this,
-ideally with a one-packet test case to verify it works when it is
-implemented.
+As a final example, we can use the `InternetChecksum` to compute an
+incremental checksum for the TCP header. Recall the TCP checksum is
+computed over the _entire_ packet, including the payload. Because the
+packet payload is not available in P4, we assume that the TCP checksum
+on the original packet is correct, and update it incrementally by
+invoking `remove` and then `update` on any fields that are modified by
+the program. For example, the ingress control in the program below
+updates the IPv4 source address, recording the original source address
+in a metadata field:    
+```
+[INCLUDE=examples/psa-example-incremental-checksum.p4:Incremental_Checksum_Table]
+```
+The deparser first updates the IPv4 checksum as above, and then
+incrementally computes the TCP checksum.         
+```
+[INCLUDE=examples/psa-example-incremental-checksum.p4:Incremental_Checksum_Example]
+```
 
 ## Counters
 

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -65,18 +65,16 @@ Replication Engine (PRE) and the Buffer Queuing Engine (BQE) are
 target dependent functional blocks that may be configured for a fixed
 set of operations.
 
-Incoming packets are parsed and have their checksums validated and are
+Incoming packets are parsed and validated, and are
 then passed to an ingress match action pipeline, which makes decisions
 on where the packets should go. After the ingress pipeline, the packet
 may be buffered and/or replicated (sent to multiple egress ports). For
 each such egress port, the packet passes through an egress match
-action pipeline and a checksum update calculation before it is
+action pipeline before it is
 deparsed and queued to leave the pipeline. Note: the checksum
 operations are available -- validation in the parser,
 and checksum computation and update in deparser (see also
-Table [#table-extern-usage])
-however, they need to be explicitly invoked though the checksum extern
-in order to be executed.
+Table [#table-extern-usage]).
 
 ~ Figure { #fig-switch; caption: "Portable Switch Pipeline"; page-align: here; }
 ![switch]
@@ -654,24 +652,28 @@ Parameters:
 [INCLUDE=psa.p4:Checksum_extern]
 ```
 
+Note that the `remove` method is only supported for the `CRC16` and
+`CRC32` hash algorithms. In particular, incremental computation of
+checksums is not supported using other hash algorithms.
+
 ### Checksum example
 
 The partial P4 program below demonstrates one way to use the
 `Checksum` extern to verify whether the checksum field in a parsed
 IPv4 header is correct, and set a parser error if it is wrong.  It
-also demonstrates checking for parser errors in the ingress control
+also demonstrates checking for parser errors in the `ingress` control
 block, dropping the packet if any errors occurred during parsing.  PSA
 programs may choose to handle packets with parser errors in other ways
 than shown in this example -- it is up to the P4 program author to
 choose and write the desired behavior.
 
 Neither P4~16~ nor the PSA provide any special mechanisms to record
-the location within a packet that a parser error occurred.  A P4
+the location within a packet that a parser error occurred. A P4
 program author can choose to record such location information
-explicitly.  For example, one may define metadata fields specifically
-for that purpose, e.g. to hold an encoded value representing the last
-parser state reached, or the number of bytes extracted so far.  Then,
-assign values to those fields within parser state code.
+explicitly. For example, one may define metadata fields specifically
+for that purpose -- e.g. to hold an encoded value representing the last
+parser state reached, or the number of bytes extracted so far -- and then 
+assign values to those fields within the parser state code.
 
 ```
 [INCLUDE=examples/psa-example-parser-checksum.p4:Parse_Error_Example]
@@ -679,7 +681,7 @@ assign values to those fields within parser state code.
 
 The partial program below demonstrates one way to use the `Checksum`
 extern to calculate and then fill in a correct IPv4 header checksum in
-the `computeChecksum` control block, just before the deparser.  In
+the deparser block.  In
 this example, the checksum is calculated fresh, so the outgoing
 checksum will be correct regardless of what changes might have been
 made to the IPv4 header fields in the ingress (or egress) control
@@ -701,7 +703,6 @@ calling `remove` on the old source/destination addresses, and then
 good to have a short example program demonstrating one way to do this,
 ideally with a one-packet test case to verify it works when it is
 implemented.
-
 
 ## Counters
 

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -636,14 +636,16 @@ TBD: Should there be a `const` defined that specifies the maximum
 allowed value of `max` parameter?
 
 
-## Checksum computation
+## Checksums
 
-Checksums and hash value generators are examples of functions that
-operate on a stream of bytes from a packet to produce an integer. The
-integer may be used, for example, as an integrity check for a packet
-or as a means to generate a pseudo-random value in a given range on a
-packet-by-packet or flow-by-flow basis.
+Checksums operate on a stream of bytes from a packet to produce an
+integer that is often used as an integrity check.
 
+### Basic checksum
+
+The basic checksum extern provided in PSA supports arbitrary hash
+algorithms.
+        
 Parameters:
 
 - W    The width of the checksum
@@ -652,14 +654,14 @@ Parameters:
 [INCLUDE=psa.p4:Checksum_extern]
 ```
 
-## Incremental checksum computation
+### Incremental checksum 
 
-PSA also provides an extern that is able to compute checksums
-incrementally. This extern provides an additional `remove` method that
-can be used to remove data previously added. It is based on the
-`ONES_COMPLEMENT16` hash algorithm used in the "Internet checksum"
-used to compute for protocols such as IPv4, TCP, and UDP -- see [IETF
-RFC 1624](https://tools.ietf.org/html/rfc1624) for details.
+In addition, PSA provides an incremental checksum that comes equipped
+with an additional `remove` method that can be used to remove data
+previously added. The checksum is computed using the
+`ONES_COMPLEMENT16` hash algorithm used with protocols such as IPv4,
+TCP, and UDP -- see [IETF RFC 1624](https://tools.ietf.org/html/rfc1624)
+for details.
 
 ```
 [INCLUDE=psa.p4:InternetChecksum_extern]    
@@ -690,11 +692,10 @@ assign values to those fields within the parser state code.
 
 The partial program below demonstrates one way to use the `Checksum`
 extern to calculate and then fill in a correct IPv4 header checksum in
-the deparser block.  In
-this example, the checksum is calculated fresh, so the outgoing
-checksum will be correct regardless of what changes might have been
-made to the IPv4 header fields in the ingress (or egress) control
-block that precedes it.
+the deparser block.  In this example, the checksum is calculated
+fresh, so the outgoing checksum will be correct regardless of what
+changes might have been made to the IPv4 header fields in the ingress
+(or egress) control block that precedes it.
 
 ```
 [INCLUDE=examples/psa-example-parser-checksum.p4:Compute_New_IPv4_Checksum_Example]

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -652,10 +652,23 @@ Parameters:
 [INCLUDE=psa.p4:Checksum_extern]
 ```
 
-Note that the `remove` method is only supported for the `CRC16` and
-`CRC32` hash algorithms. In particular, incremental computation of
-checksums is not supported using other hash algorithms.
+## Incremental checksum computation
 
+PSA also provides an extern that is able to compute checksums
+incrementally. This extern provides an additional `remove` method that
+can be used to remove data previously added. It is based on the
+`ONES_COMPLEMENT16` hash algorithm used in the "Internet checksum"
+used to compute for protocols such as IPv4, TCP, and UDP -- see [IETF
+RFC 1624](https://tools.ietf.org/html/rfc1624) for details.
+
+Parameters:
+
+- W   The width of the checksum
+
+```
+[INCLUDE=psa.p4:InternetChecksum_extern]    
+```            
+    
 ### Checksum example
 
 The partial P4 program below demonstrates one way to use the

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -167,11 +167,7 @@ control egress(inout headers hdr,
 }
 // END:Counter_Example_Part2
 
-control computeChecksum(inout headers hdr, inout metadata meta) {
-    apply { }
-}
-
-control DeparserImpl(packet_out packet, in headers hdr) {
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
@@ -180,9 +176,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 
 PSA_Switch(IngressParserImpl(),
            ingress(),
-           computeChecksum(),
            DeparserImpl(),
            EgressParserImpl(),
            egress(),
-           computeChecksum(),
            DeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-incremental-checksum.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum.p4
@@ -1,0 +1,202 @@
+/*
+Copyright 2017 Cisco Systems, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "../psa.p4"
+
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+header tcp_t {
+    bit<16> srcPort;
+    bit<16> dstPort;
+    bit<32> seqNo;
+    bit<32> ackNo;
+    bit<4>  dataOffset;
+    bit<3>  res;
+    bit<3>  ecn;
+    bit<6>  ctrl;
+    bit<16> window;
+    bit<16> checksum;
+    bit<16> urgentPtr;
+}
+
+struct fwd_metadata_t {
+    bit<32> old_srcAddr;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+    tcp_t            tcp;
+}
+
+
+// Define additional error values, one of them for packets with
+// incorrect IPv4 header checksums.
+error {
+    UnhandledIPv4Options,
+    BadIPv4HeaderChecksum
+}
+
+typedef bit<32> PacketCounter_t;
+typedef bit<8>  ErrorIndex_t;
+
+const bit<9> NUM_ERRORS = 256;
+
+parser IngressParserImpl(packet_in buffer,
+                         out headers parsed_hdr,
+                         inout metadata user_meta,
+                         in psa_ingress_parser_input_metadata_t istd,
+                         out psa_parser_output_metadata_t ostd)
+{
+    state start {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        verify(parsed_hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
+        transition select(parsed_hdr.ipv4.protocol) {
+            6: parse_tcp;
+            default: accept;
+        }
+    }
+    state parse_tcp {
+        buffer.extract(parsed_hdr.tcp);
+        transition accept;
+    }
+}
+
+// BEGIN:Incremental_Checksum_Table    
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                PacketReplicationEngine pre,
+                in  psa_ingress_input_metadata_t  istd,
+                out psa_ingress_output_metadata_t ostd) {
+    action drop() {
+      ingress_drop(ostd);
+    }
+    action forward(PortId_t port, bit<32> srcAddr) {
+      user_meta.fwd_metadata.old_srcAddr = hdr.ipv4.srcAddr;
+      hdr.ipv4.srcAddr = srcAddr;
+      send_to_port(ostd, port);      
+    }
+    table route {
+        key = { hdr.ipv4.dstAddr : lpm; }
+        actions = {
+          forward;
+          drop;
+        }
+    }
+    apply {
+        if(hdr.ipv4.isValid()) {
+          route.apply();
+        }
+    }
+}
+// END:Incremental_Checksum_Table        
+
+parser EgressParserImpl(packet_in buffer,
+                        out headers parsed_hdr,
+                        inout metadata user_meta,
+                        in psa_egress_parser_input_metadata_t istd,
+                        out psa_parser_output_metadata_t ostd)
+{
+    state start {
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               BufferingQueueingEngine bqe,
+               in  psa_egress_input_metadata_t  istd,
+               out psa_egress_output_metadata_t ostd)
+{
+    apply { }
+}
+
+// BEGIN:Incremental_Checksum_Example
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata user_meta) {
+    InternetChecksum() ck;
+    bit<16> hdrChecksum;
+    apply {
+        // Update IPv4 checksum
+        ck.clear();
+        ck.update({ hdr.ipv4.version,
+            hdr.ipv4.ihl,
+            hdr.ipv4.diffserv,
+            hdr.ipv4.totalLen,
+            hdr.ipv4.identification,
+            hdr.ipv4.flags,
+            hdr.ipv4.fragOffset,
+            hdr.ipv4.ttl,
+            hdr.ipv4.protocol,
+            //hdr.ipv4.hdrChecksum, // intentionally leave this out
+            hdr.ipv4.srcAddr,
+            hdr.ipv4.dstAddr });
+        hdrChecksum = ck.get();
+        // Update TCP checksum
+       ck.clear();
+       ck.remove(hdr.tcp.checksum);
+       ck.remove(user_meta.fwd_metadata.old_srcAddr);
+       ck.remove(hdr.ipv4.hdrChecksum);
+       ck.update(hdr.ipv4.srcAddr);
+       ck.update(hdrChecksum);
+       hdr.ipv4.hdrChecksum = hdrChecksum;
+       hdr.tcp.checksum = ck.get();
+       packet.emit(hdr.ethernet);
+       packet.emit(hdr.ipv4);
+       packet.emit(hdr.tcp);
+    }
+}
+// END:Incremental_Checksum_Example
+
+PSA_Switch(IngressParserImpl(),
+           ingress(),
+           DeparserImpl(),
+           EgressParserImpl(),
+           egress(),
+           DeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -88,7 +88,7 @@ parser IngressParserImpl(packet_in buffer,
                          in psa_ingress_parser_input_metadata_t istd,
                          out psa_parser_output_metadata_t ostd)
 {
-    Checksum<bit<16>>(HashAlgorithm_t.ONES_COMPLEMENT16) ck;
+    InternetChecksum() ck;
     state start {
         buffer.extract(parsed_hdr.ethernet);
         transition select(parsed_hdr.ethernet.etherType) {
@@ -103,9 +103,6 @@ parser IngressParserImpl(packet_in buffer,
         // headers with options, but this example does not handle such
         // packets.
         verify(parsed_hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
-        // TBD: Update the code below for checking the IPv4 header
-        // checksum with whatever the API we decide upon for a PSA
-        // checksum extern.
         ck.clear();
         ck.update({ parsed_hdr.ipv4.version,
                 parsed_hdr.ipv4.ihl,
@@ -211,16 +208,9 @@ control egress(inout headers hdr,
     apply { }
 }
 
-control computeChecksum(inout headers hdr, inout metadata meta) {
-    apply {
-    }
-}
-// END:Compute_New_IPv4_Checksum_Example
-
 // BEGIN:Compute_New_IPv4_Checksum_Example
-control DeparserImpl(packet_out packet, in headers hdr_) {
-    Checksum<bit<16>>(HashAlgorithm_t.ONES_COMPLEMENT16) ck;
-    headers hdr = hdr_; //TBD: or better, change declaration to inout?
+control DeparserImpl(packet_out packet, inout headers hdr_) {
+    InternetChecksum() ck;
     ck.clear();
     ck.update({ hdr.ipv4.version,
             hdr.ipv4.ihl,
@@ -240,6 +230,7 @@ control DeparserImpl(packet_out packet, in headers hdr_) {
         packet.emit(hdr.ipv4);
     }
 }
+// END:Compute_New_IPv4_Checksum_Example
 
 PSA_Switch(IngressParserImpl(),
            ingress(),

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -209,25 +209,26 @@ control egress(inout headers hdr,
 }
 
 // BEGIN:Compute_New_IPv4_Checksum_Example
-control DeparserImpl(packet_out packet, inout headers hdr_) {
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     InternetChecksum() ck;
-    ck.clear();
-    ck.update({ hdr.ipv4.version,
-            hdr.ipv4.ihl,
-            hdr.ipv4.diffserv,
-            hdr.ipv4.totalLen,
-            hdr.ipv4.identification,
-            hdr.ipv4.flags,
-            hdr.ipv4.fragOffset,
-            hdr.ipv4.ttl,
-            hdr.ipv4.protocol,
-            //hdr.ipv4.hdrChecksum, // intentionally leave this out
-            hdr.ipv4.srcAddr,
-            hdr.ipv4.dstAddr });
-    hdr.ipv4.hdrChecksum = ck.get();
     apply {
+        ck.clear();
+        ck.update({ hdr.ipv4.version,
+                hdr.ipv4.ihl,
+                hdr.ipv4.diffserv,
+                hdr.ipv4.totalLen,
+                hdr.ipv4.identification,
+                hdr.ipv4.flags,
+                hdr.ipv4.fragOffset,
+                hdr.ipv4.ttl,
+                hdr.ipv4.protocol,
+                //hdr.ipv4.hdrChecksum, // intentionally leave this out
+                hdr.ipv4.srcAddr,
+                hdr.ipv4.dstAddr });
+        hdr.ipv4.hdrChecksum = ck.get();
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
+        packet.emit(hdr.tcp);
     }
 }
 // END:Compute_New_IPv4_Checksum_Example

--- a/p4-16/psa/examples/psa-example-register1.p4
+++ b/p4-16/psa/examples/psa-example-register1.p4
@@ -138,11 +138,7 @@ control egress(inout headers hdr,
     apply { }
 }
 
-control computeChecksum(inout headers hdr, inout metadata meta) {
-    apply { }
-}
-
-control DeparserImpl(packet_out packet, in headers hdr) {
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
@@ -151,9 +147,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 
 PSA_Switch(IngressParserImpl(),
            ingress(),
-           computeChecksum(),
            DeparserImpl(),
            EgressParserImpl(),
            egress(),
-           computeChecksum(),
            DeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -151,7 +151,7 @@ control computeChecksum(inout headers hdr, inout metadata meta) {
     apply { }
 }
 
-control DeparserImpl(packet_out packet, in headers hdr) {
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
@@ -160,9 +160,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 
 PSA_Switch(IngressParserImpl(),
            ingress(),
-           computeChecksum(),
            DeparserImpl(),
            EgressParserImpl(),
            egress(),
-           computeChecksum(),
            DeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -132,11 +132,7 @@ control egress(inout headers hdr,
     apply { }
 }
 
-control computeChecksum(inout headers hdr, inout metadata meta) {
-    apply { }
-}
-
-control DeparserImpl(packet_out packet, in headers hdr) {
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
@@ -145,9 +141,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 
 PSA_Switch(IngressParserImpl(),
            ingress(),
-           computeChecksum(),
            DeparserImpl(),
            EgressParserImpl(),
            egress(),
-           computeChecksum(),
            DeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -127,11 +127,7 @@ control egress(inout headers hdr,
     apply { }
 }
 
-control computeChecksum(inout headers hdr, inout metadata meta) {
-    apply { }
-}
-
-control DeparserImpl(packet_out packet, in headers hdr) {
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
@@ -140,9 +136,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 
 PSA_Switch(IngressParserImpl(),
            ingress(),
-           computeChecksum(),
            DeparserImpl(),
            EgressParserImpl(),
            egress(),
-           computeChecksum(),
            DeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -134,11 +134,7 @@ control egress(inout headers hdr,
     apply { }
 }
 
-control computeChecksum(inout headers hdr, inout metadata meta) {
-    apply { }
-}
-
-control DeparserImpl(packet_out packet, in headers hdr) {
+control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
@@ -147,9 +143,7 @@ control DeparserImpl(packet_out packet, in headers hdr) {
 
 PSA_Switch(IngressParserImpl(),
            ingress(),
-           computeChecksum(),
            DeparserImpl(),
            EgressParserImpl(),
            egress(),
-           computeChecksum(),
            DeparserImpl()) main;

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -329,15 +329,33 @@ extern Checksum<W> {
   /// Add data to checksum  
   void update<T>(in T data);
     
-  /// Remove data from existing checksum
-  /// Only supported if hash is CRC{16,32}
-  void remove<T>(in T data);
-
   /// Get checksum for data added (and not removed) since last clear                               
   W    get();
 }
 // END:Checksum_extern
 
+// BEGIN:InternetChecksum_extern
+// Checksum based on `ONES_COMPLEMENT16` algorithm used in IPv4, TCP, and UDP.
+// Supports incremental updating via `remove` method.
+// See IETF RFC 1624.
+extern InternetChecksum<W> {
+  /// Constructor
+  Checksum();
+    
+  /// Reset internal state and prepare unit for computation 
+  void clear();
+
+  /// Add data to checksum  
+  void update<T>(in T data);
+
+  /// Remove data from existing checksum
+  void remove<T>(in T data);
+        
+  /// Get checksum for data added (and not removed) since last clear                               
+  W    get();
+}
+// END:InternetChecksum_extern
+    
 // BEGIN:CounterType_defn
 enum CounterType_t {
     PACKETS,

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -610,7 +610,7 @@ control Egress<H, M>(inout H hdr, inout M user_meta,
                      in  psa_egress_input_metadata_t  istd,
                      out psa_egress_output_metadata_t ostd);
 
-control Deparser<H>(packet_out buffer, in H hdr);
+control Deparser<H>(packet_out buffer, inout H hdr, in M user_meta);
 
 package PSA_Switch<IH, IM, EH, EM>(IngressParser<IH, IM> ip,
                                    Ingress<IH, IM> ig,

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -1,5 +1,4 @@
-/*
-Copyright 2013-present Barefoot Networks, Inc.
+/* Copyright 2013-present Barefoot Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -340,7 +339,7 @@ extern Checksum<W> {
 // See IETF RFC 1624.
 extern InternetChecksum {
   /// Constructor
-  Checksum();
+  InternetChecksum();
     
   /// Reset internal state and prepare unit for computation
   void clear();
@@ -610,14 +609,14 @@ control Egress<H, M>(inout H hdr, inout M user_meta,
                      in  psa_egress_input_metadata_t  istd,
                      out psa_egress_output_metadata_t ostd);
 
-control Deparser<H>(packet_out buffer, inout H hdr, in M user_meta);
+control Deparser<H, M>(packet_out buffer, inout H hdr, in M user_meta);
 
 package PSA_Switch<IH, IM, EH, EM>(IngressParser<IH, IM> ip,
                                    Ingress<IH, IM> ig,
-                                   Deparser<IH> id,
+                                   Deparser<IH, IM> id,
                                    EgressParser<EH, EM> ep,
                                    Egress<EH, EM> eg,
-                                   Deparser<EH> ed);
+                                   Deparser<EH, EM> ed);
 // END:Programmable_blocks
 
 #endif  /* _PORTABLE_SWITCH_ARCHITECTURE_P4_ */

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -322,14 +322,14 @@ extern Hash<O> {
 extern Checksum<W> {
   /// Constructor
   Checksum(HashAlgorithm_t hash);
-    
-  /// Reset internal state and prepare unit for computation 
+
+  /// Reset internal state and prepare unit for computation
   void clear();
 
-  /// Add data to checksum  
+  /// Add data to checksum
   void update<T>(in T data);
-    
-  /// Get checksum for data added (and not removed) since last clear                               
+
+  /// Get checksum for data added (and not removed) since last clear
   W    get();
 }
 // END:Checksum_extern
@@ -338,21 +338,21 @@ extern Checksum<W> {
 // Checksum based on `ONES_COMPLEMENT16` algorithm used in IPv4, TCP, and UDP.
 // Supports incremental updating via `remove` method.
 // See IETF RFC 1624.
-extern InternetChecksum<W> {
+extern InternetChecksum {
   /// Constructor
   Checksum();
     
-  /// Reset internal state and prepare unit for computation 
+  /// Reset internal state and prepare unit for computation
   void clear();
 
-  /// Add data to checksum  
+  /// Add data to checksum
   void update<T>(in T data);
 
   /// Remove data from existing checksum
   void remove<T>(in T data);
         
-  /// Get checksum for data added (and not removed) since last clear                               
-  W    get();
+  /// Get checksum for data added (and not removed) since last clear
+  bit<16>    get();
 }
 // END:InternetChecksum_extern
     

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -320,11 +320,21 @@ extern Hash<O> {
 
 // BEGIN:Checksum_extern
 extern Checksum<W> {
-  Checksum(HashAlgorithm_t hash);          /// constructor
-  void clear();              /// prepare unit for computation
-  void update<T>(in T data); /// add data to checksum
-  void remove<T>(in T data); /// remove data from existing checksum
-  W    get();      	     /// get the checksum for data added since last clear
+  /// Constructor
+  Checksum(HashAlgorithm_t hash);
+    
+  /// Reset internal state and prepare unit for computation 
+  void clear();
+
+  /// Add data to checksum  
+  void update<T>(in T data);
+    
+  /// Remove data from existing checksum
+  /// Only supported if hash is CRC{16,32}
+  void remove<T>(in T data);
+
+  /// Get checksum for data added (and not removed) since last clear                               
+  W    get();
 }
 // END:Checksum_extern
 
@@ -582,17 +592,13 @@ control Egress<H, M>(inout H hdr, inout M user_meta,
                      in  psa_egress_input_metadata_t  istd,
                      out psa_egress_output_metadata_t ostd);
 
-control ComputeChecksum<H, M>(inout H hdr, inout M user_meta);
-
 control Deparser<H>(packet_out buffer, in H hdr);
 
 package PSA_Switch<IH, IM, EH, EM>(IngressParser<IH, IM> ip,
                                    Ingress<IH, IM> ig,
-                                   ComputeChecksum<IH, IM> ic,
                                    Deparser<IH> id,
                                    EgressParser<EH, EM> ep,
                                    Egress<EH, EM> eg,
-                                   ComputeChecksum<EH, EM> ec,
                                    Deparser<EH> ed);
 // END:Programmable_blocks
 

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -280,7 +280,7 @@ extern recirculate {
   /// Write @hdr into the egress packet.
   /// @T can be a header type, a header stack, a header union or a struct
   /// containing fields with such types.
-  void emit(in T hdr);
+  void emit<T>(in T hdr);
 }
 // END:Recirculate_extern
 


### PR DESCRIPTION
This PR implements changes discussed in preceding working group meetings. Note that I missed the last meeting, so I am going from the notes and discussions with those who attended -- i.e., it possible something got lost in translation.

The major changes include:
* Remove `ComputeChecksum` control and require checksum computation and update to be done in deparser.

* Clarifying that incremental checksumming is only supported for CRC{16,32}.

To discuss:

* Should we indeed move checksum updates to deparser?

* What do to with deparser direction annotations? Can copy the headers to a new variable, but it's a shame that we have to do that.

* Is my undersatnding of the intended restrictions on incrmental checksums correct? In particular, calling `update` many times is fine, but calling `remove` is only okay for CRC{16,32}. 

* Add an example of incremental TCP checksum?