### PR TITLE
[do not merge] restores PR #381: Proposed additions to P4_16 spec: restrictions on use of stateful objects

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6515,9 +6515,8 @@ parameters: parsers, controls, extern methods, and actions.
 | value types | yes       | yes     | yes     | yes     |
 |-------------|-----------|---------|---------|---------|
 
-The restrictions on return types of extern methods is the same as for
-parameters, with the addition that `void` can be a return type for
-methods that return no value.
+Extern method calls may return only return a value that is a value
+type, or no value at all (specified by a return type of `void`).
 
 The next table lists restrictions on what kinds of calls can be made
 from which places in a P4 program.  Calling a parser, control, or

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6479,9 +6479,10 @@ implementation.  Thus there is no place to instantiate objects within
 an extern.
 
 You may declare variables and constants of any of the value types
-within a parser or control.  Declaring a variable or constant is not
-the same as instantiation, hence the answer "no" in those table
-entries.  Variables may not be declared at the top level of your
+within a parser or control (see Section [#sec-variables] for more
+details).  Declaring a variable or constant is not the same as
+instantiation, hence the answer "N/A" (for not applicable) in those
+table entries.  Variables may not be declared at the top level of your
 program, but constants may.
 
 |-------------|-------------------------------------------------|
@@ -6494,7 +6495,7 @@ program, but constants may.
 | control     |  no       |  no     | no      | yes     |  no    |
 | extern      | yes       |  no     | yes     | yes     |  no    |
 | table       |  no       |  no     | no      | yes     |  no    |
-| value types |  no       |  no     | no      | no      |  no    |
+| value types | N/A       | N/A     |N/A      |N/A      | N/A    |
 |-------------|-----------|---------|---------|---------|--------|
 
 The next table lists restrictions on what types can be passed as

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6523,21 +6523,25 @@ from which places in a P4 program.  Calling a parser, control, or
 table means invoking its `apply()` method.  The row for `extern`
 describes where extern method calls can be made from.
 
+One way that an extern can be called from the top level of a parser or
+control is in an initializer expression for a declared variable,
+e.g. `bit<32> x = rand.get();`.
+
 |-------------|-------------------------------------------------|
-|             | can be called at run time from this place in a P4 program ||||
-|             |-----------|---------|---------|--------|
-|             |           | control |         |        |
-|             | parser    | apply   |         |        |
-| This type   | state     | block   | action  | extern |
-+-------------+:---------:+:-------:+:-------:+:------:+
-| package     | N/A       | N/A     | N/A     | N/A    |
-| parser      | yes       |  no     | no      | no     |
-| control     |  no       | yes     | no      | no     |
-| extern      | yes       | yes     | yes     | no     |
-| table       |  no       | yes     | no      | no     |
-| action      |  no       | yes     | yes     | no     |
-| value types | N/A       | N/A     | N/A     | N/A    |
-|-------------|-----------|---------|---------|--------|
+|             | can be called at run time from this place in a P4 program |||||
+|             |-----------|---------|-----------|---------|--------|
+|             |           | control | parser or |         |        |
+|             | parser    | apply   | control   |         |        |
+| This type   | state     | block   | top level | action  | extern |
++-------------+:---------:+:-------:+:---------:+:-------:+:------:+
+| package     | N/A       | N/A     | N/A       | N/A     | N/A    |
+| parser      | yes       |  no     | no        | no      | no     |
+| control     |  no       | yes     | no        | no      | no     |
+| extern      | yes       | yes     | yes       | yes     | no     |
+| table       |  no       | yes     | no        | no      | no     |
+| action      |  no       | yes     | no        | yes     | no     |
+| value types | N/A       | N/A     | N/A       | N/A     | N/A    |
+|-------------|-----------|---------|-----------|---------|--------|
 
 There may not be any recursion in calls, neither by a thing calling
 itself directly, nor mutual recursion.

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6525,19 +6525,19 @@ describes where extern method calls can be made from.
 
 |-------------|-------------------------------------------------|
 |             | can be called at run time from this place in a P4 program |||||
-|             |-----------|---------|---------|------------|--------|
-|             |           | control | action  | action not |        |
-|             | parser    | apply   | used by | used by    |        |
-| This type   | state     | block   | table   | any table  | extern |
-+-------------+:---------:+:-------:+:-------:+:----------:+:------:+
-| package     | N/A       | N/A     | N/A     | N/A        | N/A    |
-| parser      | yes       |  no     | no      | no         | no     |
-| control     |  no       | yes     | no      | yes        | no     |
-| extern      | yes       | yes     | yes     | yes        | no     |
-| table       |  no       | yes     | no      | yes        | no     |
-| action      |  no       | yes     | yes     | yes        | no     |
-| value types | N/A       | N/A     | N/A     | N/A        | N/A    |
-|-------------|-----------|---------|---------|------------|--------|
+|             |-----------|---------|---------|--------|
+|             |           | control |         |        |
+|             | parser    | apply   |         |        |
+| This type   | state     | block   | action  | extern |
++-------------+:---------:+:-------:+:-------:+:------:+
+| package     | N/A       | N/A     | N/A     | N/A    |
+| parser      | yes       |  no     | no      | no     |
+| control     |  no       | yes     | no      | no     |
+| extern      | yes       | yes     | yes     | no     |
+| table       |  no       | yes     | no      | no     |
+| action      |  no       | yes     | yes     | no     |
+| value types | N/A       | N/A     | N/A     | N/A    |
+|-------------|-----------|---------|---------|--------|
 
 There may not be any recursion in calls, neither by a thing calling
 itself directly, nor mutual recursion.
@@ -6545,20 +6545,7 @@ itself directly, nor mutual recursion.
 An extern can never cause any other type of P4 program object to be
 called.  See Section [#sec-calling-convention-justification].
 
-An "action used by a table" means an action that is either in the
-`actions` list of a table, or it is possible for the action to be
-called from such an action, perhaps through one or more intermediate
-action calls.
-
-Any action can be called from a control `apply` block.
-
-It is allowed to write actions that are not used by any table.  Such
-"actions not used by any table" have exactly the same restrictions on
-what they can call as a control `apply` block does.  A potential
-convenience of creating such an action is that it can be defined
-within the control that calls it, giving the action access to all
-parameter values and local variables defined earlier within its
-enclosing control.  By contrast, control definitions cannot be nested.
+Any action can be called directly from a control `apply` block.
 
 Note that while the extern row shows that extern methods can be called
 from many places, particular externs may have additional restrictions

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1558,7 +1558,7 @@ When used as arguments, `extern` objects can only be passed as
 directionless parameters---e.g., see the packet argument in the
 very simple switch example.
 
-### Justification
+### Justification { #sec-calling-convention-justification }
 
 The main reason for using copy-in/copy-out semantics (instead of the more common
 call-by-reference semantics) is for controlling the side-effects of `extern`
@@ -6415,6 +6415,160 @@ h.ipv4.ttl = h.ipv4.ttl - 1;
 ck16.update( { h.ipv4.ttl, h.ipv4.proto } );
 h.ipv4.hdrChecksum = ck16.get();
 ~ End P4Example
+
+
+# Appendix: Restrictions on compile time and run time calls
+
+This appendix summarizes restrictions on compile time and run time
+calls that can be made.  Many of them are described earlier in this
+document, but are collected here for easy reference.
+
+The stateful types of objects in P4~16~ are packages, parsers,
+controls, externs, and tables.  All other types are referred to as
+"value types" here.
+
+Some guiding principles:
+
+- Packages can be instantiated, but have no run-time behavior, so
+  there is no use in passing them to anything else other than another
+  package.
+- Controls are not allowed to call parsers, and vice versa, so there
+  is no use in passing one type to the other in constructor parameters
+  or run-time parameters.
+- At run time, after a control is called, and before that call is
+  complete, there can be no recursive calls between controls, nor from
+  a control to itself.  Similarly for parsers.  There can be loops
+  among states within a single parser.
+- Externs are not allowed to call parsers or controls, so there is no
+  use in passing objects of those types to them.
+- Tables are always instantiated directly in their enclosing control,
+  and cannot be instantiated at the top level.  There is no type by
+  which a table can be passed as either a constructor or run-time
+  parameter anywhere else.  They are only intended to be used from
+  within the control where they are defined.
+
+A note on recursion: It is expected that some architectures will
+define capabilities for recirculating a packet to be processed again
+as if it were a newly arriving packet, or to make "clones" of packets
+that are then processed by parsers and/or control blocks that the
+original packet has already completed.  This does not change the notes
+above on recursion that apply while a parser or control is executing.
+
+The first table lists restrictions on what types can be passed as
+constructor parameters to other types.
+
+|-------------|-------------------------------------------------|
+|             | can be a constructor parameter for this type ||||
+|             |---------|--------|---------|--------|
+| This type   | package | parser | control | extern |
++-------------+:-------:+:------:+:-------:+:------:+
+| package     | yes     |  no    |  no     |  no    |
+| parser      | yes     | yes    |  no     |  no    |
+| control     | yes     |  no    | yes     |  no    |
+| extern      | yes     | yes    | yes     | yes    |
+| table       |  no     |  no    |  no     |  no    |
+| value types | yes     | yes    | yes     | yes    |
+|-------------|---------|--------|---------|--------|
+
+The next table lists restrictions on what types can be instantiated
+where.  The answer for `package` is always "no" because there is no
+"inside a package" where instantiations can be written in P4~16~.  One
+can definitely make constructor calls and use instances of stateful
+types as parameters when instantiating a package, and restrictions on
+those types are in the table above.
+
+For externs, their implementations are typically written in some other
+language, and so what can be instantiated inside of them is not the
+concern of the P4~16~ language.
+
+The entries for "value types" are yes for parsers and controls,
+because you can define variables of any of those types inside of
+parsers and controls.  Variables of these types may not be defined at
+the top level of your program.
+
+|-------------|-------------------------------------------------|
+|             | can be instantiated in this place |||||
+|             |-----------|---------|---------|---------|--------|
+| This type   | top level | package | parser  | control | extern |
++-------------+:---------:+:-------:+:-------:+:-------:+:------:+
+| package     | yes       |  no     | no      | no      |  no    |
+| parser      |  no       |  no     | yes     | no      |  no    |
+| control     |  no       |  no     | no      | yes     |  no    |
+| extern      | yes       |  no     | yes     | yes     |  no    |
+| table       |  no       |  no     | no      | yes     |  no    |
+| value types |  no       |  no     | yes     | yes     |  no    |
+|-------------|-----------|---------|---------|---------|--------|
+
+The next table lists restrictions on what types can be passed as
+run-time parameters to other callable things that have run-time
+parameters: parsers, controls, extern methods, and actions.
+
+|-------------|-------------------------------------------------|
+|             | can be a run-time parameter to this callable thing ||||
+|             |-----------|---------|---------|---------|
+| This type   | parser    | control | method  | action  |
++-------------+:---------:+:-------:+:-------:+:-------:+
+| package     |  no       |  no     | no      | no      |
+| parser      |  no       |  no     | no      | no      |
+| control     |  no       |  no     | no      | no      |
+| extern      | yes       | yes     | yes     | no      |
+| table       |  no       |  no     | no      | no      |
+| value types | yes       | yes     | yes     | yes     |
+|-------------|-----------|---------|---------|---------|
+
+The restrictions on return types of extern methods is the same as for
+parameters, with the addition that `void` can be a return type for
+methods that return no value.
+
+The next table lists restrictions on what kinds of calls can be made
+from which places in a P4 program.  Calling a parser, control, or
+table means invoking its `apply()` method.  The row for `extern`
+describes where extern method calls can be made from.
+
+|-------------|-------------------------------------------------|
+|             | can be called at run time from this place in a P4 program |||||
+|             |-----------|---------|---------|------------|--------|
+|             |           | control | action  | action not |        |
+|             | parser    | apply   | used by | used by    |        |
+| This type   | state     | block   | table   | any table  | extern |
++-------------+:---------:+:-------:+:-------:+:----------:+:------:+
+| package     | N/A       | N/A     | N/A     | N/A        | N/A    |
+| parser      | yes       |  no     | no      | no         | no     |
+| control     |  no       | yes     | no      | yes        | no     |
+| extern      | yes       | yes     | yes     | yes        | no     |
+| table       |  no       | yes     | no      | yes        | no     |
+| action      |  no       | yes     | yes     | yes        | no     |
+| value types | N/A       | N/A     | N/A     | N/A        | N/A    |
+|-------------|-----------|---------|---------|------------|--------|
+
+There may not be any recursion in calls, neither by a thing calling
+itself directly, nor mutual recursion.
+
+An extern can never cause any other type of P4 program object to be
+called.  See Section [#sec-calling-convention-justification].
+
+An "action used by a table" means an action that is either in the
+`actions` list of a table, or it is possible for the action to be
+called from such an action, perhaps through one or more intermediate
+action calls.
+
+Any action can be called from a control `apply` block.
+
+It is allowed to write actions that are not used by any table.  Such
+"actions not used by any table" have exactly the same restrictions on
+what they can call as a control `apply` block does.  A potential
+convenience of creating such an action is that it can be defined
+within the control that calls it, giving the action access to all
+parameter values and local variables defined earlier within its
+enclosing control.  By contrast, control definitions cannot be nested.
+
+Note that while the extern row shows that extern methods can be called
+from many places, particular externs may have additional restrictions
+not listed in this table.  Any such restrictions should be documented
+in the description for each extern.  In most cases, it is expected
+that the restriction will be "from a parser state only" or "from a
+control apply block or action only".
+
 
 # Appendix: Open Issues
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6429,9 +6429,6 @@ controls, externs, and tables.  All other types are referred to as
 
 Some guiding principles:
 
-- Packages can be instantiated, but have no run-time behavior, so
-  there is no use in passing them to anything else other than another
-  package.
 - Controls are not allowed to call parsers, and vice versa, so there
   is no use in passing one type to the other in constructor parameters
   or run-time parameters.
@@ -6442,10 +6439,9 @@ Some guiding principles:
 - Externs are not allowed to call parsers or controls, so there is no
   use in passing objects of those types to them.
 - Tables are always instantiated directly in their enclosing control,
-  and cannot be instantiated at the top level.  There is no type by
-  which a table can be passed as either a constructor or run-time
-  parameter anywhere else.  They are only intended to be used from
-  within the control where they are defined.
+  and cannot be instantiated at the top level.  There is no syntax for
+  specifying parameters that are tables.  Tables are only intended to
+  be used from within the control where they are defined.
 
 A note on recursion: It is expected that some architectures will
 define capabilities for recirculating a packet to be processed again
@@ -6470,21 +6466,23 @@ constructor parameters to other types.
 | value types | yes     | yes    | yes     | yes    |
 |-------------|---------|--------|---------|--------|
 
-The next table lists restrictions on what types can be instantiated
-where.  The answer for `package` is always "no" because there is no
+The next table lists restrictions on where one may perform
+instantiations (see Section [#sec-instantiations]) of different types.
+The answer for `package` is always "no" because there is no
 "inside a package" where instantiations can be written in P4~16~.  One
 can definitely make constructor calls and use instances of stateful
 types as parameters when instantiating a package, and restrictions on
 those types are in the table above.
 
-For externs, their implementations are typically written in some other
-language, and so what can be instantiated inside of them is not the
-concern of the P4~16~ language.
+For externs, one can only specify their interface in P4~16~, not their
+implementation.  Thus there is no place to instantiate objects within
+an extern.
 
-The entries for "value types" are yes for parsers and controls,
-because you can define variables of any of those types inside of
-parsers and controls.  Variables of these types may not be defined at
-the top level of your program.
+You may declare variables and constants of any of the value types
+within a parser or control.  Declaring a variable or constant is not
+the same as instantiation, hence the answer "no" in those table
+entries.  Variables may not be declared at the top level of your
+program, but constants may.
 
 |-------------|-------------------------------------------------|
 |             | can be instantiated in this place |||||
@@ -6496,7 +6494,7 @@ the top level of your program.
 | control     |  no       |  no     | no      | yes     |  no    |
 | extern      | yes       |  no     | yes     | yes     |  no    |
 | table       |  no       |  no     | no      | yes     |  no    |
-| value types |  no       |  no     | yes     | yes     |  no    |
+| value types |  no       |  no     | no      | no      |  no    |
 |-------------|-----------|---------|---------|---------|--------|
 
 The next table lists restrictions on what types can be passed as

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6524,7 +6524,7 @@ table means invoking its `apply()` method.  The row for `extern`
 describes where extern method calls can be made from.
 
 |-------------|-------------------------------------------------|
-|             | can be called at run time from this place in a P4 program |||||
+|             | can be called at run time from this place in a P4 program ||||
 |             |-----------|---------|---------|--------|
 |             |           | control |         |        |
 |             | parser    | apply   |         |        |
@@ -6545,7 +6545,7 @@ itself directly, nor mutual recursion.
 An extern can never cause any other type of P4 program object to be
 called.  See Section [#sec-calling-convention-justification].
 
-Any action can be called directly from a control `apply` block.
+Actions may be called directly from a control `apply` block.
 
 Note that while the extern row shows that extern methods can be called
 from many places, particular externs may have additional restrictions

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6550,9 +6550,13 @@ Any action can be called directly from a control `apply` block.
 Note that while the extern row shows that extern methods can be called
 from many places, particular externs may have additional restrictions
 not listed in this table.  Any such restrictions should be documented
-in the description for each extern.  In most cases, it is expected
-that the restriction will be "from a parser state only" or "from a
-control apply block or action only".
+in the description for each extern, as part of the documentation for
+the architecture that defines the extern.
+
+In many cases, the restriction will be "from a parser state only" or
+"from a control apply block or action only", but it may be even more
+restrictive, e.g. only from a particular kind of control block
+instantiated in a particular role in an architecture.
 
 
 # Appendix: Open Issues


### PR DESCRIPTION
This PR re-applies the changes that were submitted as part of #381 and which need to wait for the language working group discussion.