### PR TITLE
Change direction of some Ingress and Egress parameters from out to inout

### DIFF
--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -113,8 +113,8 @@ parser EgressParserImpl(packet_in buffer,
 control ingress(inout headers hdr,
                 inout metadata user_meta,
                 PacketReplicationEngine pre,
-                in  psa_ingress_input_metadata_t  istd,
-                out psa_ingress_output_metadata_t ostd)
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
 {
     Counter<ByteCounter_t, PortId_t>((bit<32>) NUM_PORTS, CounterType_t.BYTES)
         port_bytes_in;
@@ -152,8 +152,8 @@ control ingress(inout headers hdr,
 control egress(inout headers hdr,
                inout metadata user_meta,
                BufferingQueueingEngine bqe,
-               in  psa_egress_input_metadata_t  istd,
-               out psa_egress_output_metadata_t ostd)
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
 {
     Counter<ByteCounter_t, PortId_t>((bit<32>) NUM_PORTS, CounterType_t.BYTES)
         port_bytes_out;

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -140,8 +140,8 @@ parser IngressParserImpl(packet_in buffer,
 control ingress(inout headers hdr,
                 inout metadata user_meta,
                 PacketReplicationEngine pre,
-                in  psa_ingress_input_metadata_t  istd,
-                out psa_ingress_output_metadata_t ostd)
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
 {
     // Table parser_error_count_and_convert below shows one way to
     // count the number of times each parser error was encountered.
@@ -205,8 +205,8 @@ parser EgressParserImpl(packet_in buffer,
 control egress(inout headers hdr,
                inout metadata user_meta,
                BufferingQueueingEngine bqe,
-               in  psa_egress_input_metadata_t  istd,
-               out psa_egress_output_metadata_t ostd)
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -107,8 +107,8 @@ parser IngressParserImpl(packet_in buffer,
 control ingress(inout headers hdr,
                 inout metadata user_meta,
                 PacketReplicationEngine pre,
-                in  psa_ingress_input_metadata_t  istd,
-                out psa_ingress_output_metadata_t ostd)
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
 {
     Register<PacketByteCountState_t, PortId_t>((bit<32>) NUM_PORTS)
         port_pkt_ip_bytes_in;
@@ -141,8 +141,8 @@ parser EgressParserImpl(packet_in buffer,
 control egress(inout headers hdr,
                inout metadata user_meta,
                BufferingQueueingEngine bqe,
-               in  psa_egress_input_metadata_t  istd,
-               out psa_egress_output_metadata_t ostd)
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -104,8 +104,8 @@ parser IngressParserImpl(packet_in buffer,
 control ingress(inout headers hdr,
                 inout metadata user_meta,
                 PacketReplicationEngine pre,
-                in  psa_ingress_input_metadata_t  istd,
-                out psa_ingress_output_metadata_t ostd)
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
 {
     apply {
         ostd.egress_port = 0;
@@ -126,8 +126,8 @@ parser EgressParserImpl(packet_in buffer,
 control egress(inout headers hdr,
                inout metadata user_meta,
                BufferingQueueingEngine bqe,
-               in  psa_egress_input_metadata_t  istd,
-               out psa_egress_output_metadata_t ostd)
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -99,8 +99,8 @@ parser IngressParserImpl(packet_in buffer,
 control ingress(inout headers hdr,
                 inout metadata user_meta,
                 PacketReplicationEngine pre,
-                in  psa_ingress_input_metadata_t  istd,
-                out psa_ingress_output_metadata_t ostd)
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
 {
     apply {
         ostd.egress_port = 0;
@@ -121,8 +121,8 @@ parser EgressParserImpl(packet_in buffer,
 control egress(inout headers hdr,
                inout metadata user_meta,
                BufferingQueueingEngine bqe,
-               in  psa_egress_input_metadata_t  istd,
-               out psa_egress_output_metadata_t ostd)
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -106,8 +106,8 @@ parser IngressParserImpl(packet_in buffer,
 control ingress(inout headers hdr,
                 inout metadata user_meta,
                 PacketReplicationEngine pre,
-                in  psa_ingress_input_metadata_t  istd,
-                out psa_ingress_output_metadata_t ostd)
+                in    psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
 {
     apply {
         ostd.egress_port = 0;
@@ -128,8 +128,8 @@ parser EgressParserImpl(packet_in buffer,
 control egress(inout headers hdr,
                inout metadata user_meta,
                BufferingQueueingEngine bqe,
-               in  psa_egress_input_metadata_t  istd,
-               out psa_egress_output_metadata_t ostd)
+               in    psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -280,7 +280,7 @@ extern recirculate {
   /// Write @hdr into the egress packet.
   /// @T can be a header type, a header stack, a header union or a struct
   /// containing fields with such types.
-  void emit(in T hdr);
+  void emit<T>(in T hdr);
 }
 // END:Recirculate_extern
 
@@ -568,8 +568,8 @@ parser IngressParser<H, M>(packet_in buffer,
 
 control Ingress<H, M>(inout H hdr, inout M user_meta,
                       PacketReplicationEngine pre,
-                      in  psa_ingress_input_metadata_t  istd,
-                      out psa_ingress_output_metadata_t ostd);
+                      in    psa_ingress_input_metadata_t  istd,
+                      inout psa_ingress_output_metadata_t ostd);
 
 parser EgressParser<H, M>(packet_in buffer,
                           out H parsed_hdr,
@@ -579,8 +579,8 @@ parser EgressParser<H, M>(packet_in buffer,
 
 control Egress<H, M>(inout H hdr, inout M user_meta,
                      BufferingQueueingEngine bqe,
-                     in  psa_egress_input_metadata_t  istd,
-                     out psa_egress_output_metadata_t ostd);
+                     in    psa_egress_input_metadata_t  istd,
+                     inout psa_egress_output_metadata_t ostd);
 
 control ComputeChecksum<H, M>(inout H hdr, inout M user_meta);
 


### PR DESCRIPTION
We want these structs to have fields with defined values when the
Ingress and Egress control blocks begin execution.  This cannot be
done if they are defined as direction 'out', but can if they are
defined as direction 'inout'.

Also adds a missing type parameter <T> to one emit method definition
in psa.p4 that caused compilation errors.