### PR TITLE
Simplify the Random extern for uniform distributions only

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -1133,17 +1133,17 @@ $2^W$ entries.
 
 ## Random
 
-The random extern provides a reliable, target specific number generator
-in the min .. max range.
+The `Random` extern provides generation of pseudo-random numbers in a
+specified range with a uniform distribution.  If one wishes to
+generate numbers with a non-uniform distribution, you may do so by
+first generating a uniformly distributed random value, and then using
+appropriate table lookups and/or arithmetic on the resulting value to
+achieve the desired distribution.
 
-
-The set of distributions supported by the Random extern.
-\TODO: should this be removed in favor of letting the extern
-return whatever distribution is supported by the target?
-
-```
-[INCLUDE=psa.p4:RandomDistribution_defn]
-```
+An implementation is not required to produce cryptographically strong
+pseudo-random number generation.  For example, a particularly
+inexpensive implementation might use a linear feedback shift register
+to generate values.
 
 ```
 [INCLUDE=psa.p4:Random_extern]

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -460,17 +460,9 @@ extern Register<T, S> {
 }
 // END:Register_extern
 
-// BEGIN:RandomDistribution_defn
-enum RandomDistribution {
-  PRNG,
-  Binomial,
-  Poisson
-}
-// END:RandomDistribution_defn
-
 // BEGIN:Random_extern
 extern Random<T> {
-  Random(RandomDistribution dist, T min, T max);
+  Random(T min, T max);
   T read();
 
   /*


### PR DESCRIPTION
The text briefly mentions how a user's P4 program can use this to
generate pseudo-random values with non-uniform distributions.