### PR TITLE
Fix typo in PSA

### DIFF
--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -280,7 +280,7 @@ extern recirculate {
   /// Write @hdr into the egress packet.
   /// @T can be a header type, a header stack, a header union or a struct
   /// containing fields with such types.
-  void emit(in T hdr);
+  void emit<T>(in T hdr);
 }
 // END:Recirculate_extern
 


### PR DESCRIPTION
The `emit` method for the `recirculate` extern was missing the declaration of type parameter `T`.