### PR TITLE
PSA: Updates to InternetChecksum extern

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -782,7 +782,7 @@ Parameters:
 ### Incremental checksum { #sec-incremental-checksum }
 
 PSA also provides an incremental checksum that comes equipped with an
-additional `remove` method that can be used to remove data previously
+additional `subtract` method that can be used to remove data previously
 added. The checksum is computed using the `ONES_COMPLEMENT16` hash
 algorithm used with protocols such as IPv4, TCP, and UDP -- see [IETF
 RFC 1624](https://tools.ietf.org/html/rfc1624) for details.
@@ -831,7 +831,7 @@ incremental checksum for the TCP header. Recall the TCP checksum is
 computed over the _entire_ packet, including the payload. Because the
 packet payload is not available in P4, we assume that the TCP checksum
 on the original packet is correct, and update it incrementally by
-invoking `remove` and then `update` on any fields that are modified by
+invoking `subtract` and then `add` on any fields that are modified by
 the program. For example, the ingress control in the program below
 updates the IPv4 source address, recording the original source address
 in a metadata field:
@@ -1754,7 +1754,7 @@ types, as the P4 program author wishes.
 
 # Appendix: Implementation of the `InternetChecksum` extern
 
-Besides RFC 1461, RFC 1071 and RFC 1141 contain useful tips on
+Besides RFC 1461, RFC 1071 and RFC 1141 also contain useful tips on
 efficiently computing the Internet checksum, especially in software
 implementations.
 
@@ -1808,5 +1808,13 @@ void remove<T>(in T data) {
 
 bit<16> get() {
     return ~sum;
+}
+
+bit<16> get_state() {
+    return sum;
+}
+
+void set_state(bit<16> checksum_state) {
+    sum = checksum_state;
 }
 ```

--- a/p4-16/psa/examples/psa-example-incremental-checksum.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum.p4
@@ -160,7 +160,7 @@ control DeparserImpl(packet_out packet, inout headers hdr, in metadata user_meta
     apply {
         // Update IPv4 checksum
         ck.clear();
-        ck.update({
+        ck.add({
             /* 16-bit word  0   */ hdr.ipv4.version, hdr.ipv4.ihl, hdr.ipv4.diffserv,
             /* 16-bit word  1   */ hdr.ipv4.totalLen,
             /* 16-bit word  2   */ hdr.ipv4.identification,
@@ -174,13 +174,13 @@ control DeparserImpl(packet_out packet, inout headers hdr, in metadata user_meta
         // Update TCP checksum
         ck.clear();
         // Subtract the original TCP checksum
-        ck.remove(hdr.tcp.checksum);
+        ck.subtract(hdr.tcp.checksum);
         // Subtract the effect of the original IPv4 source address,
         // which is part of the TCP 'pseudo-header' for the purposes
         // of TCP checksum calculation (see RFC 793), then add the
         // effect of the new IPv4 source address.
-        ck.remove(user_meta.fwd_metadata.old_srcAddr);
-        ck.update(hdr.ipv4.srcAddr);
+        ck.subtract(user_meta.fwd_metadata.old_srcAddr);
+        ck.add(hdr.ipv4.srcAddr);
         hdr.tcp.checksum = ck.get();
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -104,7 +104,7 @@ parser IngressParserImpl(packet_in buffer,
         // packets.
         verify(parsed_hdr.ipv4.ihl == 5, error.UnhandledIPv4Options);
         ck.clear();
-        ck.update({ parsed_hdr.ipv4.version,
+        ck.add({ parsed_hdr.ipv4.version,
                 parsed_hdr.ipv4.ihl,
                 parsed_hdr.ipv4.diffserv,
                 parsed_hdr.ipv4.totalLen,
@@ -213,7 +213,7 @@ control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
     InternetChecksum() ck;
     apply {
         ck.clear();
-        ck.update({ hdr.ipv4.version,
+        ck.add({ hdr.ipv4.version,
                 hdr.ipv4.ihl,
                 hdr.ipv4.diffserv,
                 hdr.ipv4.totalLen,

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -346,22 +346,33 @@ extern Checksum<W> {
 extern InternetChecksum {
   /// Constructor
   InternetChecksum();
-    
+
   /// Reset internal state and prepare unit for computation
   void clear();
 
   /// Add data to checksum.  data must be a multiple of 16 bits long.
-  void update<T>(in T data);
+  void add<T>(in T data);
 
-  /// Remove data from existing checksum.  data must be a multiple of
+  /// Subtract data from existing checksum.  data must be a multiple of
   /// 16 bits long.
-  void remove<T>(in T data);
-        
+  void subtract<T>(in T data);
+
   /// Get checksum for data added (and not removed) since last clear
-  bit<16>    get();
+  bit<16> get();
+
+  /// Get current state of checksum computation.  The return value is
+  /// only intended to be used for a future call to the set_state
+  /// method.
+  bit<16> get_state();
+
+  /// Restore the state of the InternetChecksum instance to one
+  /// returned from an earlier call to the get_state method.  This
+  /// state could hae been returned from the same instance of the
+  /// InternetChecksum extern, or a different one.
+  void set_state(bit<16> checksum_state);
 }
 // END:InternetChecksum_extern
-    
+
 // BEGIN:CounterType_defn
 enum CounterType_t {
     PACKETS,

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -367,7 +367,7 @@ extern InternetChecksum {
 
   /// Restore the state of the InternetChecksum instance to one
   /// returned from an earlier call to the get_state method.  This
-  /// state could hae been returned from the same instance of the
+  /// state could have been returned from the same instance of the
   /// InternetChecksum extern, or a different one.
   void set_state(bit<16> checksum_state);
 }


### PR DESCRIPTION
Discussed at 2017-Nov-01 PSA working group meeting.

Keep clear and get methods as is.

Rename update to add.  Rename remove to subtract.

Add get_state method for returning the internal checksum state from an
InternetChecksum instance in one parser or control, and set_state
method for causing an instance to go to that same state.  Useful for
some kinds of incremental checksum computation performed across
different parsers or control blocks.