### PR TITLE
PSA - Update examples for latest psa.p4 file

### DIFF
--- a/p4-16/psa/examples/psa-example-clone-to-port.p4
+++ b/p4-16/psa/examples/psa-example-clone-to-port.p4
@@ -127,7 +127,6 @@ parser IngressParserImpl(packet_in buffer,
 // BEGIN:Clone_Example_Part2
 control ingress(inout headers hdr,
                 inout metadata user_meta,
-                PacketReplicationEngine pre,
                 in  psa_ingress_input_metadata_t  istd,
                 inout psa_ingress_output_metadata_t ostd)
 {
@@ -165,7 +164,6 @@ parser EgressParserImpl(packet_in buffer,
 
 control egress(inout headers hdr,
                inout metadata user_meta,
-               BufferingQueueingEngine bqe,
                in  psa_egress_input_metadata_t  istd,
                inout psa_egress_output_metadata_t ostd)
 {
@@ -209,9 +207,12 @@ control EgressDeparserImpl(packet_out packet,
     }
 }
 
-PSA_Switch(IngressParserImpl(),
-           ingress(),
-           IngressDeparserImpl(),
-           EgressParserImpl(),
-           egress(),
-           EgressDeparserImpl()) main;
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_SWITCH(ip, ep) main;

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -103,7 +103,6 @@ parser IngressParserImpl(packet_in buffer,
 
 control ingress(inout headers hdr,
                 inout metadata user_meta,
-                PacketReplicationEngine pre,
                 in    psa_ingress_input_metadata_t  istd,
                 inout psa_ingress_output_metadata_t ostd)
 {
@@ -125,23 +124,51 @@ parser EgressParserImpl(packet_in buffer,
 
 control egress(inout headers hdr,
                inout metadata user_meta,
-               BufferingQueueingEngine bqe,
                in    psa_egress_input_metadata_t  istd,
                inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }
 
-control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
     }
 }
 
-PSA_Switch(IngressParserImpl(),
-           ingress(),
-           DeparserImpl(),
-           EgressParserImpl(),
-           egress(),
-           DeparserImpl()) main;
+control IngressDeparserImpl(packet_out buffer,
+                            clone_out cl,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           clone_out cl,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_SWITCH(ip, ep) main;

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -98,7 +98,6 @@ parser IngressParserImpl(packet_in buffer,
 
 control ingress(inout headers hdr,
                 inout metadata user_meta,
-                PacketReplicationEngine pre,
                 in    psa_ingress_input_metadata_t  istd,
                 inout psa_ingress_output_metadata_t ostd)
 {
@@ -120,23 +119,51 @@ parser EgressParserImpl(packet_in buffer,
 
 control egress(inout headers hdr,
                inout metadata user_meta,
-               BufferingQueueingEngine bqe,
                in    psa_egress_input_metadata_t  istd,
                inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }
 
-control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
     }
 }
 
-PSA_Switch(IngressParserImpl(),
-           ingress(),
-           DeparserImpl(),
-           EgressParserImpl(),
-           egress(),
-           DeparserImpl()) main;
+control IngressDeparserImpl(packet_out buffer,
+                            clone_out cl,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           clone_out cl,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_SWITCH(ip, ep) main;

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -105,7 +105,6 @@ parser IngressParserImpl(packet_in buffer,
 
 control ingress(inout headers hdr,
                 inout metadata user_meta,
-                PacketReplicationEngine pre,
                 in    psa_ingress_input_metadata_t  istd,
                 inout psa_ingress_output_metadata_t ostd)
 {
@@ -127,23 +126,51 @@ parser EgressParserImpl(packet_in buffer,
 
 control egress(inout headers hdr,
                inout metadata user_meta,
-               BufferingQueueingEngine bqe,
                in    psa_egress_input_metadata_t  istd,
                inout psa_egress_output_metadata_t ostd)
 {
     apply { }
 }
 
-control DeparserImpl(packet_out packet, inout headers hdr, in metadata meta) {
+control CommonDeparserImpl(packet_out packet,
+                           inout headers hdr)
+{
     apply {
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
     }
 }
 
-PSA_Switch(IngressParserImpl(),
-           ingress(),
-           DeparserImpl(),
-           EgressParserImpl(),
-           egress(),
-           DeparserImpl()) main;
+control IngressDeparserImpl(packet_out buffer,
+                            clone_out cl,
+                            inout headers hdr,
+                            in metadata meta,
+                            in psa_ingress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+control EgressDeparserImpl(packet_out buffer,
+                           clone_out cl,
+                           inout headers hdr,
+                           in metadata meta,
+                           in psa_egress_output_metadata_t istd)
+{
+    CommonDeparserImpl() cp;
+    apply {
+        cp.apply(buffer, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_SWITCH(ip, ep) main;


### PR DESCRIPTION
Nothing deep here -- just the same kind of changes made yesterday to update one of the examples for the new psa.p4 control and package definitions.  They all compile cleanly with the latest p4test again (modulo a few warnings about ostd not being completely initialized, which is normal).