### PR TITLE
PSA Fix syntax error psa.p4

### DIFF
--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -556,7 +556,7 @@ extern ActionSelector {
 // BEGIN:Digest_extern
 extern Digest<T> {
   Digest(PortId_t receiver);         /// define a digest stream to receiver
-  void pack<T>(in T data);           /// emit data into the stream
+  void pack(in T data);           /// emit data into the stream
 
   /*
   @ControlPlaneAPI


### PR DESCRIPTION
Without this change, a recent version of p4test gives an error while
attempting to compile this code.