### PR TITLE
add an example to do recirculate in PSA

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -440,19 +440,14 @@ the contents of several metadata fields in the struct
 
 The function `platform_port_valid()` mentioned below takes a value of
 type `PortId_t`, returning `true` only when the value represents an
-output port for the implementation.  It is expected that for some PSA
+output port for the implementation. It is expected that for some PSA
 implementations there will be bit patterns for a value of type
-`PortId_t` that do not correspond to any port.  This function returns
-true for `PORT_CPU`, but false for `PORT_RECIRCULATE`.
-`PORT_RECIRCULATE` is only intended as a value for `ingress_port` when
-ingress processing begins for a recirculated packet (see Table
-[#ingress-initial-values].  See section [#sec-after-egress] for how P4
-programs cause a packet to be recirculated). `platform_port_valid`
-is not defined in PSA for calling from the P4 data-plane
-program, since there is no known use case for calling it at packet
-processing time. It is intended for describing the behavior in pseudo-code.
-The control plane is expected to configure tables
-with valid port numbers.
+`PortId_t` that do not correspond to any port. This function returns
+true for both `PORT_CPU` and `PORT_RECIRCULATE`. `platform_port_valid`
+is not defined in PSA for calling from the P4 data-plane program,
+since there is no known use case for calling it at packet processing
+time. It is intended for describing the behavior in pseudo-code. The
+control plane is expected to configure tables with valid port numbers.
 
 A comment saying "recommended to log error" is not a requirement, but
 a recommendation, that a PSA implementation should maintain a counter
@@ -1033,10 +1028,13 @@ pipeline, and used in the second pass. See Section
 [#sec-open-metadata] for the discussion.
 
 The `recirculate` flag specifies whether a packet should be
-recirculated. If true, the processed packet should be recirculated at
-the end of the egress pipeline with the optional metadata. If false,
-the recirculation mechanism is disabled and no assignments to
-`recirc_meta` should be performed.
+recirculated and it is a read-only value in the egress deparser. The
+`recirculate` flag is set to true if the `egress_port` is set to
+`PORT_RECIRCULATE` in the ingress pipeline, otherwise, the flag is set
+to false. If the `recirculate` flag is true, the processed packet
+should be recirculated at the end of the egress pipeline with the
+optional metadata. If false, the recirculation mechanism is disabled
+and no assignments to `recirc_meta` should be performed.
 
 # PSA Externs
 

--- a/p4-16/psa/examples/psa-example-recirculate.p4
+++ b/p4-16/psa/examples/psa-example-recirculate.p4
@@ -117,7 +117,7 @@ control ingress(inout headers hdr,
                 inout psa_ingress_output_metadata_t ostd)
 {
     action do_recirc (PortId_t port) {
-        ostd.egress_port = PORT_RECIRCULATE;
+        send_to_port(ostd, PORT_RECIRCULATE);
     }
     table t {
         key = {

--- a/p4-16/psa/examples/psa-example-recirculate.p4
+++ b/p4-16/psa/examples/psa-example-recirculate.p4
@@ -1,0 +1,208 @@
+
+/*
+Copyright 2017 Barefoot Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <core.p4>
+#include "../psa.p4"
+
+typedef bit<48>  EthernetAddress;
+
+header ethernet_t {
+    EthernetAddress dstAddr;
+    EthernetAddress srcAddr;
+    bit<16>         etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    bit<32> srcAddr;
+    bit<32> dstAddr;
+}
+
+struct fwd_metadata_t {
+    bit<32> outport;
+}
+
+struct empty_metadata_t {}
+
+header recirc_metadata_t {
+    bit<8> custom_field;
+}
+
+struct metadata {
+    fwd_metadata_t fwd_metadata;
+    bit<3> custom_clone_id;
+    recirc_metadata_t recirc_header;
+}
+
+struct headers {
+    ethernet_t       ethernet;
+    ipv4_t           ipv4;
+}
+
+parser CommonParser(packet_in buffer,
+                    out headers parsed_hdr,
+                    inout metadata user_meta)
+{
+    state start {
+        transition parse_ethernet;
+    }
+    state parse_ethernet {
+        buffer.extract(parsed_hdr.ethernet);
+        transition select(parsed_hdr.ethernet.etherType) {
+            0x0800: parse_ipv4;
+            default: accept;
+        }
+    }
+    state parse_ipv4 {
+        buffer.extract(parsed_hdr.ipv4);
+        transition accept;
+    }
+}
+
+parser IngressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_ingress_parser_input_metadata_t istd,
+    in empty_metadata_t resub_meta,
+    in recirc_metadata_t recirc_meta,
+    out psa_parser_output_metadata_t ostd)
+{
+    CommonParser() p;
+
+    state start {
+        transition select(istd.packet_path) {
+           PacketPath_t.RECIRCULATE: parse_recirc_header;
+           PacketPath_t.NORMAL: parse_ethernet;
+        }
+    }
+
+    state parse_recirc_header {
+        user_meta.recirc_header = recirc_meta;
+	transition accept;
+    }
+
+    state parse_ethernet {
+        p.apply(buffer, parsed_hdr, user_meta);
+	transition accept;
+    }
+}
+
+control ingress(inout headers hdr,
+                inout metadata user_meta,
+                in  psa_ingress_input_metadata_t  istd,
+                inout psa_ingress_output_metadata_t ostd)
+{
+    action do_recirc (PortId_t port) {
+        ostd.egress_port = PORT_RECIRCULATE;
+    }
+    table t {
+        key = {
+            user_meta.fwd_metadata.outport : exact;
+        }
+        actions = { do_recirc; }
+    }
+
+    apply {
+        t.apply();
+    }
+}
+
+parser EgressParserImpl(
+    packet_in buffer,
+    out headers parsed_hdr,
+    inout metadata user_meta,
+    in psa_egress_parser_input_metadata_t istd,
+    in empty_metadata_t normal_meta,
+    in empty_metadata_t clone_i2e_meta,
+    in empty_metadata_t cloen_e2e_meta,
+    out psa_parser_output_metadata_t ostd)
+{
+    CommonParser() p;
+
+    state start {
+        p.apply(buffer, parsed_hdr, user_meta);
+        transition accept;
+    }
+}
+
+control egress(inout headers hdr,
+               inout metadata user_meta,
+               in  psa_egress_input_metadata_t  istd,
+               inout psa_egress_output_metadata_t ostd)
+{
+    apply {
+    }
+}
+
+control DeparserImpl(packet_out packet, inout headers hdr) {
+    apply {
+        packet.emit(hdr.ethernet);
+        packet.emit(hdr.ipv4);
+    }
+}
+
+control IngressDeparserImpl(
+    packet_out packet,
+    out empty_metadata_t clone_i2e_meta,
+    out empty_metadata_t resub_meta,
+    out empty_metadata_t normal_meta,
+    inout headers hdr,
+    in metadata meta,
+    in psa_ingress_output_metadata_t istd)
+{
+    DeparserImpl() common_deparser;
+    apply {
+        common_deparser.apply(packet, hdr);
+    }
+}
+
+control EgressDeparserImpl(
+    packet_out packet,
+    out empty_metadata_t clone_e2e_meta,
+    out recirc_metadata_t recirc_meta,
+    inout headers hdr,
+    in metadata meta,
+    in psa_egress_output_metadata_t istd)
+{
+    DeparserImpl() common_deparser;
+    apply {
+        if (psa_recirculate(istd)) {
+            recirc_meta.custom_field = 8w1;
+        }
+        common_deparser.apply(packet, hdr);
+    }
+}
+
+IngressPipeline(IngressParserImpl(),
+                ingress(),
+                IngressDeparserImpl()) ip;
+
+EgressPipeline(EgressParserImpl(),
+               egress(),
+               EgressDeparserImpl()) ep;
+
+PSA_SWITCH(ip, ep) main;

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -125,8 +125,8 @@ struct psa_egress_output_metadata_t {
   // Egress control block begins executing.
   bool                     clone;         // false
   ClassOfService_t         clone_class_of_service; // 0
+  bool                     recirculate;   // set by environment
   bool                     drop;          // false
-  bool                     recirculate;   // false
   bool                     truncate;      // false
   PacketLength_t           truncate_payload_bytes;  // undefined
 }


### PR DESCRIPTION
One attempt to do recirculate in PSA and updated some text.

So far, it seems the `recirculate` flag is still necessary to inform the egress deparser that the ingress pipeline has made a decision to recirculate a packet by setting the `egress_port` to `PORT_RECIRCULATE`. The egress deparser needs to know if a packet is recirculation packet by either checking the `egress_port == PORT_RECIRCULATE` or checking `recirculate_flag == 1`. The issue with `egress_port` is that it is not in the `psa_egress_output_metadata_t`, and therefore not visible in egress deparser. On the other hand, the `recirculate` flag is visible in egress deparser. But the caveat is that the `recirculate` flag should be read-only and should be set by the environment. However, `recirculate` flag is currently in `psa_egress_output_metadata_t` which allows both read and write by the egress pipeline.

