### PR TITLE
Update PSA example programs for latest version of psa.p4

### DIFF
--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -16,15 +16,43 @@ build/${SPEC}.pdf: psa.p4
 clean:
 	${RM} -rf build
 
-P4C=p4test
+# Disabling warnings about uninitialized_out_param, because those
+# regularly occur with these example programs for the 'out
+# psa_parser_output_metadata_t ostd' parameter of the parsers.
+
+P4C=p4test --Wdisable=uninitialized_out_param
 
 check:
+	${P4C} examples/psa-example-bridged-metadata.p4
+	${P4C} examples/psa-example-clone-to-port.p4
 	${P4C} examples/psa-example-counters.p4
+	${P4C} examples/psa-example-incremental-checksum.p4
+	${P4C} examples/psa-example-parser-checksum.p4
+	${P4C} examples/psa-example-register2.p4
 	${P4C} examples/psa-example-value-sets.p4
 	${P4C} examples/psa-example-value-sets2.p4
 	${P4C} examples/psa-example-value-sets3.p4
-	${P4C} examples/psa-example-register2.p4
-	${P4C} examples/psa-example-parser-checksum.p4
-	${P4C} examples/psa-example-incremental-checksum.p4
-	${P4C} examples/psa-example-clone-to-port.p4
-	${P4C} examples/psa-example-bridged-metadata.p4
+
+check-others:
+
+# psa-example-digest.p4 needs updates for latest psa.p4
+#	${P4C} examples/psa-example-digest.p4
+
+# psa-example-mirror-on-drop.p4 needs updates for latest psa.p4
+#	${P4C} examples/psa-example-mirror-on-drop.p4
+
+# psa-example-resubmit.p4 needs updates for latest psa.p4
+#	${P4C} examples/psa-example-resubmit.p4
+
+# psa-example-incremental-checksum2.p4 fails with latest p4test as of
+# 2017-Dec-04 because of call to InternetChecksum method set_state(),
+# because its argument is not a compile-time constant.  I am not sure
+# why that should be a problem.
+#	${P4C} examples/psa-example-incremental-checksum2.p4
+
+# psa-example-register1.p4 is almost identical to
+# psa-example-register2.p4, except that it attempts to return a struct
+# from a register read, and write a struct back to the register.  As
+# of 2017-Dec-04, the latest version of p4test gives an error if you
+# attempt this.
+#	${P4C} examples/psa-example-register1.p4

--- a/p4-16/psa/examples/psa-example-incremental-checksum.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum.p4
@@ -55,6 +55,9 @@ header tcp_t {
     bit<16> urgentPtr;
 }
 
+struct empty_metadata_t {
+}
+
 struct fwd_metadata_t {
     bit<32> old_srcAddr;
 }
@@ -82,6 +85,8 @@ parser IngressParserImpl(packet_in buffer,
                          out headers parsed_hdr,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta,
                          out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -137,6 +142,9 @@ parser EgressParserImpl(packet_in buffer,
                         out headers parsed_hdr,
                         inout metadata user_meta,
                         in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta,
                         out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -153,7 +161,9 @@ control egress(inout headers hdr,
 }
 
 control IngressDeparserImpl(packet_out packet,
-                            clone_out cl,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
                             inout headers hdr,
                             in metadata meta,
                             in psa_ingress_output_metadata_t istd)
@@ -167,7 +177,8 @@ control IngressDeparserImpl(packet_out packet,
 
 // BEGIN:Incremental_Checksum_Example
 control EgressDeparserImpl(packet_out packet,
-                           clone_out cl,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata user_meta,
                            in psa_egress_output_metadata_t istd)

--- a/p4-16/psa/examples/psa-example-mirror-on-drop.p4
+++ b/p4-16/psa/examples/psa-example-mirror-on-drop.p4
@@ -175,9 +175,6 @@ control egress(inout headers hdr,
     apply { }
 }
 
-control computeChecksum(inout headers hdr, inout metadata meta) {}
-
-
 control DeparserImpl(packet_out packet, inout headers hdr) {
     apply {
         packet.emit(hdr.eth);
@@ -221,9 +218,7 @@ control EgressDeparserImpl(packet_out packet,
 
 PSA_Switch(IngressParserImpl(),
            ingress(),
-           computeChecksum(),
            IngressDeparserImpl(),
            EgressParserImpl(),
            egress(),
-           computeChecksum(),
            EgressDeparserImpl()) main;

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -55,6 +55,9 @@ header tcp_t {
     bit<16> urgentPtr;
 }
 
+struct empty_metadata_t {
+}
+
 struct fwd_metadata_t {
 }
 
@@ -86,6 +89,8 @@ parser IngressParserImpl(packet_in buffer,
                          out headers hdr,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta,
                          out psa_parser_output_metadata_t ostd)
 {
     InternetChecksum() ck;
@@ -189,6 +194,9 @@ parser EgressParserImpl(packet_in buffer,
                         out headers hdr,
                         inout metadata user_meta,
                         in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta,
                         out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -205,7 +213,9 @@ control egress(inout headers hdr,
 }
 
 control IngressDeparserImpl(packet_out packet,
-                            clone_out cl,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
                             inout headers hdr,
                             in metadata meta,
                             in psa_ingress_output_metadata_t istd)
@@ -219,7 +229,8 @@ control IngressDeparserImpl(packet_out packet,
 
 // BEGIN:Compute_New_IPv4_Checksum_Example
 control EgressDeparserImpl(packet_out packet,
-                           clone_out cl,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
                            in psa_egress_output_metadata_t istd)

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -41,6 +41,9 @@ header ipv4_t {
     bit<32> dstAddr;
 }
 
+struct empty_metadata_t {
+}
+
 struct fwd_metadata_t {
 }
 
@@ -85,6 +88,8 @@ parser IngressParserImpl(packet_in buffer,
                          out headers parsed_hdr,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta,
                          out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -130,6 +135,9 @@ parser EgressParserImpl(packet_in buffer,
                         out headers parsed_hdr,
                         inout metadata user_meta,
                         in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta,
                         out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -155,7 +163,9 @@ control CommonDeparserImpl(packet_out packet,
 }
 
 control IngressDeparserImpl(packet_out buffer,
-                            clone_out cl,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
                             inout headers hdr,
                             in metadata meta,
                             in psa_ingress_output_metadata_t istd)
@@ -167,7 +177,8 @@ control IngressDeparserImpl(packet_out buffer,
 }
 
 control EgressDeparserImpl(packet_out buffer,
-                           clone_out cl,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
                            in psa_egress_output_metadata_t istd)

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -41,6 +41,9 @@ header ipv4_t {
     bit<32> dstAddr;
 }
 
+struct empty_metadata_t {
+}
+
 struct fwd_metadata_t {
 }
 
@@ -58,6 +61,8 @@ parser IngressParserImpl(packet_in buffer,
                          out headers parsed_hdr,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta,
                          out psa_parser_output_metadata_t ostd)
 {
     ValueSet<bit<16>>(4) tpid_types;
@@ -115,6 +120,9 @@ parser EgressParserImpl(packet_in buffer,
                         out headers parsed_hdr,
                         inout metadata user_meta,
                         in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta,
                         out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -140,7 +148,9 @@ control CommonDeparserImpl(packet_out packet,
 }
 
 control IngressDeparserImpl(packet_out buffer,
-                            clone_out cl,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
                             inout headers hdr,
                             in metadata meta,
                             in psa_ingress_output_metadata_t istd)
@@ -152,7 +162,8 @@ control IngressDeparserImpl(packet_out buffer,
 }
 
 control EgressDeparserImpl(packet_out buffer,
-                           clone_out cl,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
                            in psa_egress_output_metadata_t istd)

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -41,6 +41,9 @@ header ipv4_t {
     bit<32> dstAddr;
 }
 
+struct empty_metadata_t {
+}
+
 struct fwd_metadata_t {
 }
 
@@ -57,6 +60,8 @@ parser IngressParserImpl(packet_in buffer,
                          out headers parsed_hdr,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta,
                          out psa_parser_output_metadata_t ostd)
 {
     ValueSet<bit<16>>(4) tpid_types;
@@ -110,6 +115,9 @@ parser EgressParserImpl(packet_in buffer,
                         out headers parsed_hdr,
                         inout metadata user_meta,
                         in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta,
                         out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -135,7 +143,9 @@ control CommonDeparserImpl(packet_out packet,
 }
 
 control IngressDeparserImpl(packet_out buffer,
-                            clone_out cl,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
                             inout headers hdr,
                             in metadata meta,
                             in psa_ingress_output_metadata_t istd)
@@ -147,7 +157,8 @@ control IngressDeparserImpl(packet_out buffer,
 }
 
 control EgressDeparserImpl(packet_out buffer,
-                           clone_out cl,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
                            in psa_egress_output_metadata_t istd)

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -41,6 +41,9 @@ header ipv4_t {
     bit<32> dstAddr;
 }
 
+struct empty_metadata_t {
+}
+
 struct fwd_metadata_t {
 }
 
@@ -63,6 +66,8 @@ parser IngressParserImpl(packet_in buffer,
                          out headers parsed_hdr,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
+                         in empty_metadata_t resubmit_meta,
+                         in empty_metadata_t recirculate_meta,
                          out psa_parser_output_metadata_t ostd)
 {
     ValueSet<CustomValueSet1_t>(2) trill_types;
@@ -117,6 +122,9 @@ parser EgressParserImpl(packet_in buffer,
                         out headers parsed_hdr,
                         inout metadata user_meta,
                         in psa_egress_parser_input_metadata_t istd,
+                        in empty_metadata_t normal_meta,
+                        in empty_metadata_t clone_i2e_meta,
+                        in empty_metadata_t clone_e2e_meta,
                         out psa_parser_output_metadata_t ostd)
 {
     state start {
@@ -142,7 +150,9 @@ control CommonDeparserImpl(packet_out packet,
 }
 
 control IngressDeparserImpl(packet_out buffer,
-                            clone_out cl,
+                            out empty_metadata_t clone_i2e_meta,
+                            out empty_metadata_t resubmit_meta,
+                            out empty_metadata_t normal_meta,
                             inout headers hdr,
                             in metadata meta,
                             in psa_ingress_output_metadata_t istd)
@@ -154,7 +164,8 @@ control IngressDeparserImpl(packet_out buffer,
 }
 
 control EgressDeparserImpl(packet_out buffer,
-                           clone_out cl,
+                           out empty_metadata_t clone_e2e_meta,
+                           out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
                            in psa_egress_output_metadata_t istd)


### PR DESCRIPTION
Nothing fancy here -- just updating the other PSA example programs for the most recent changes in psa.p4.  Only one or two of them were updated when psa.p4 was last changed, to test those changes at least a little bit, but waiting for the changes to settle a bit before 'catching up' to the latest version with the rest of the examples.