### PR TITLE
Many edits to clean up move of recirculate decision to ingress

### DIFF
--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -28,7 +28,9 @@ check:
 	${P4C} examples/psa-example-counters.p4
 	${P4C} examples/psa-example-incremental-checksum.p4
 	${P4C} examples/psa-example-parser-checksum.p4
+	${P4C} examples/psa-example-recirculate.p4
 	${P4C} examples/psa-example-register2.p4
+	${P4C} examples/psa-example-resubmit.p4
 	${P4C} examples/psa-example-value-sets.p4
 	${P4C} examples/psa-example-value-sets2.p4
 	${P4C} examples/psa-example-value-sets3.p4
@@ -40,9 +42,6 @@ check-others:
 
 # psa-example-mirror-on-drop.p4 needs updates for latest psa.p4
 #	${P4C} examples/psa-example-mirror-on-drop.p4
-
-# psa-example-resubmit.p4 needs updates for latest psa.p4
-#	${P4C} examples/psa-example-resubmit.p4
 
 # psa-example-incremental-checksum2.p4 fails with latest p4test as of
 # 2017-Dec-04 because of call to InternetChecksum method set_state(),

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -580,8 +580,8 @@ A similar FIFO property is expected to hold for multicast packets,
 i.e. those that follow the "Make 0 or more copies" path in the
 pseudocode above.  By a short period of time after the control plane
 has stopped modifying the set of members of multicast groups, they
-should be 'stable', and all packets with the same `(ingress_port,`
-`ostd.multicast_group,` `ostd.class_of_service,` `egress_port)` should
+should be 'stable', and all packets with the same (`ingress_port`,
+`ostd.multicast_group`, `ostd.class_of_service`, `egress_port`) should
 pass through the system in FIFO order, and be processed in the
 `Egress` control block in the same relative order that they were
 processed in the `Ingress` control block.
@@ -999,27 +999,10 @@ modified packet after egress processing, as output by the egress
 deparser.  In both cases, the cloned packet is submitted to the egress
 pipeline for further processing.
 
-Logically, PRE implements the mechanics of copying a packet.  PRE
-reads the original packet as it began ingress parsing, or the modified
-packet from the egress deparser.  PRE then decides which version of
-the packet to use to generate a copy based on the value of the
-metadata provided by the ingress and egress pipeline.  The metadata
-fields that control cloning are those whose names begin with `clone`
-in types `psa_ingress_output_metadata_t` and
+Logically, PRE implements the mechanics of copying a packet.  The
+metadata fields that control cloning are those whose names begin with
+`clone` in types `psa_ingress_output_metadata_t` and
 `psa_egress_output_metadata_t`.
-
-~ TBD
-The sentence beginning "PRE then decides which version of the packet
-to use to generate a copy" makes it sound like either you can create a
-clone of a packet in the ingress pipeline, or you can create a clone
-of a packet in the egress pipeline, but you cannot do both for the
-same packet.  The ingress and egress executions of packets, whether
-they occur due to the same original packet or different ones, are
-pretty much independent events, true?
-
-If so, it would be good to reword, or eliminate, that sentence and any
-text that could be misinterpreted in that way.
-~
 
 ```
 bool                     clone;
@@ -1126,9 +1109,9 @@ different headers than the packet had before recirculation.  This
 could be useful in implementing features such as multiple levels of
 tunnel encapsulation or decapsulation.
 
-Packet recirculation happens at the end of the egress pipeline, but
-whether a packet is recirculated must be chosen during ingress
-processing, by sending the packet to port `PORT_RECIRCULATE`.  When a
+Whether a packet is recirculated must be chosen during ingress
+processing, by sending the packet to port `PORT_RECIRCULATE`.  Packet
+recirculation happens at the end of the egress pipeline.  When a
 packet is sent to the recirculate port, the packet finishes egress
 processing, including the egress deparser, and then re-enters the
 ingress parser.  The `ingress_port` of the recirculated packet is set
@@ -1255,23 +1238,26 @@ a part of the PSA pipeline that is not programmable via writing P4
 code.
 
 Even though the PRE can not be programmed using P4, it can be
-configured both directly using control plane APIs and by setting
-intrinsic metadata.  The file `psa.p4` defines some actions
-to help set these metadata fields for some common use cases, described
-in sections [#sec-ingress-actions] and [#sec-egress-actions].
+configured using control plane APIs, e.g. configuring multicast groups
+and clone sessions.  For every packet, your P4 program will typically
+assign values to intrinsic metadata in structs such as those of type
+`psa_ingress_output_metadata_t` and `psa_egress_output_metadata_t`,
+which direct the operation of the PRE on that packet.  The file
+`psa.p4` defines some actions to help set these metadata fields for
+some common use cases, described in sections [#sec-ingress-actions]
+and [#sec-egress-actions].
 
-The PRE extern object has no constructor, and thus it cannot be
-instantiated in the user's P4 program. The architecture instantiates
-it exactly once, without requiring the user's P4 program to
-instantiate it. The PRE is made available to the `PSA_Switch` package.
+The PRE extern must be instantiated exactly once, in the `PSA_Switch`
+package instantiation.  See near the end of Section
+[#sec-programmable-blocks] for the package definitions from `psa.p4`.
+See below for an example of instantiating these packages, including
+the instantiation of one instance of `PacketReplicationEngine` and one
+of `BufferingQueueingEngine` in the `PSA_Switch` package
+instantiation.
 
-~ TBD
-The statement "The PRE extern object has no constructor" is currently
-wrong.  We should either make it correct by changing psa.p4 somehow,
-or update the text above to match psa.p4.
-
-The same comment applies for the BQE section below.
-~
+```
+[INCLUDE=examples/psa-example-counters.p4:Package_Instantiation_Example]
+```
 
 
 ## Buffering Queuing Engine {#sec-bqe}
@@ -1284,10 +1270,8 @@ Even though the BQE can not be programmed using P4, it can be
 configured both directly using control plane APIs and by setting
 intrinsic metadata.
 
-The BQE extern object has no constructor, and thus it cannot be
-instantiated in the user's P4 program. The architecture instantiates
-it exactly once, without requiring the user's P4 program to
-instantiate it. The BQE is made available to the `PSA_Switch` package.
+The BQE extern must be instantiated exactly once, as the PRE must.
+See Section [#sec-pre] for additional discussion and example code.
 
 
 ## Hashes {#sec-hash-algorithms}

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -214,12 +214,17 @@ There are metadata fields defined by PSA that enable your P4 program
 to identify which path each packet arrived on, and to control where it
 will go next.  See section [#packet-path-details].
 
-For egress packets, the choice of egress port, or the port to the CPU,
-is made by the immediately previous processing step (ingress for NU,
-NM, or CI2E packets, egress for CE2E packets), and egress processing
-cannot change that choice to a different port.  It can change the
-packet to RECIRC instead, or drop the packet.  Ingress code is the
-intended place in your P4 program where the output port(s) are chosen.
+For egress packets, the choice between one of multiple egress ports,
+the port to the CPU, or the "recirculation port", is made by the
+immediately previous processing step (ingress for NU, NM, or CI2E
+packets, egress for CE2E packets).  Egress processing can choose to
+drop the packet instead of sending it to the port chosen earlier, but
+it cannot change the choice to a different port.  Ingress code is the
+most common place in a P4 program where the output port(s) are chosen.
+The only exception to ingress choosing the output port is for
+egress-to-egress clone packets, whose destination port is chosen when
+the clone is created in the immediately preceding egress processing
+step.  See [#tbd] for the rationale for this restriction.
 
 A single packet received by a PSA system from a port can result in 0,
 1, or many packets going out, all under control of the P4 program.
@@ -230,13 +235,13 @@ the following to occur, if the P4 program so directed it:
   creates a CI2E clone destined for the CPU port (copy 1), and a
   multicast NM packet to multicast group 18, which is configured in
   the PacketReplicationEngine to have copies made to ports 5 (copy 2)
-  and 7 (copy 3).
+  and the recirculate port `PORT_RECIRCULATE` (copy 3).
 + Copy 1 performs egress processing, which sends the packet on path
   NTCPU to the CPU port.
 + Copy 2 performs egress processing, which creates a CE2E clone
   destined for port 8 (copy 4), and sends a NTP packet to port 5.
 + Copy 3 performs egress processing, which does a RECIRC back to
-  ingress instead of sending the packet to port 7 (copy 5).
+  ingress (copy 5).
 + Copy 4 performs egress processing, which sends a NTP packet to port
   8.
 + Copy 5 performs ingress processing, which sends a NU packet destined
@@ -573,15 +578,15 @@ A similar FIFO property is expected to hold for multicast packets,
 i.e. those that follow the "Make 0 or more copies" path in the
 pseudocode above.  By a short period of time after the control plane
 has stopped modifying the set of members of multicast groups, they
-should be 'stable', and all packets with the same `(ingress_port,
-ostd.multicast_group, ostd.class_of_service, egress_port)` should pass
-through the system in FIFO order, and be processed in the `Egress`
-control block in the same relative order that they were processed in
-the `Ingress` control block.
+should be 'stable', and all packets with the same `(ingress_port,`
+`ostd.multicast_group,` `ostd.class_of_service,` `egress_port)` should
+pass through the system in FIFO order, and be processed in the
+`Egress` control block in the same relative order that they were
+processed in the `Ingress` control block.
 
 There is no such expectation for multicast packets with different
 `class_of_service` values, again because of separate queues in the PRE
-for different class_of_service values.
+for different `class_of_service` values.
 
 The control plane API excerpt below is an example intended to be added as part of
 the P4 Runtime API, and the final version of this message will be defined
@@ -668,9 +673,8 @@ complete, not at the time one of these actions is called.  See Section
 These actions are provided for convenience in making changes to these
 metadata fields.  Their effects are expected to be common kinds of
 changes one will want to make in a P4 program.  If they do not suit
-your use cases, you are of course welcome to modify the metadata
-fields directly in your P4 programs however you prefer, perhaps within
-actions you define yourself.
+your use cases, you may modify the metadata fields directly in your P4
+programs however you prefer, e.g. within actions you define.
 
 
 ### Unicast operation
@@ -690,8 +694,8 @@ Sends packet to a multicast group or a port.  See Table
 filled in when each multicast-replicated copy of such a packet begins
 egress processing.
 
-The multicast_group parameter is the multicast group id. The control
-plane must configure the multicast groups through a separate
+The `multicast_group` parameter is the multicast group id.  The
+control plane must configure the multicast groups through a separate
 mechanism such as the P4 Runtime API.
 
 ```
@@ -773,12 +777,21 @@ headers as emitted by the ingress deparser, followed by the payload of
 that packet, i.e. the part that was not parsed by the ingress parser.
 Truncation of the payload is supported.
 
+Packets to be recirculated, i.e. those sent to port `PORT_RECIRCULATE`
+via the normal unicast or multicast packet paths, fit into this
+category.  They are not treated differently by a PSA implementation
+from normal unicast or multicast packets until they reach the egress
+deparser.
+
 ### Initial packet contents for packets cloned from ingress to egress
 
 For CI2E packets, `packet_in` is from the ingress packet that caused
 this clone to be created.  It is the same as the pre-IngressParser
 contents of `packet_in` of that ingress packet, with no modifications
 from any ingress processing.  Truncation of the payload is supported.
+
+Packets cloned in ingress using a clone session configured with
+`clone_port` equal to `PORT_RECIRCULATE` fit into this category.
 
 
 ### Initial packet contents for packets cloned from egress to egress
@@ -788,6 +801,9 @@ clone to be created.  It starts with the headers emitted by the egress
 deparser, followed by the payload of that packet, i.e. the part that
 was not parsed by the egress parser.  Truncation of the payload is
 supported.
+
+Packets cloned in egress using a clone session configured with
+`clone_port` equal to `PORT_RECIRCULATE` fit into this category.
 
 
 ### User-defined metadata for all egress packets
@@ -812,7 +828,7 @@ with defined contents.  Its value is the one that was assigned to the
 `out` parameter with the same name of the ingress deparser, when the
 clone was created.
 
-For CLONE_I2E packets, the parameter `clone_e2e_meta` is the only one
+For CLONE_E2E packets, the parameter `clone_e2e_meta` is the only one
 with defined contents.  Its value is the one that was assigned to the
 `out` parameter with the same name of the egress deparser, when the
 clone was created.
@@ -971,22 +987,37 @@ its normal destination according to other features implemented by the
 P4 program, and in addition, send a copy of the packet as received to
 another output port, e.g. to a monitoring device.
 
-Packet cloning happens at the end of the ingress and/or egress pipeline. PSA
-specifies the following semantics for clone operation. When the clone
-operation is invoked at the end of the ingress pipeline, the cloned
-packet is a copy of the original packet from ingress port. When the
-clone operation is invoked at the end of egress pipeline, the cloned
-packet is a copy of the modified packet after egress processing. In
-both cases, the cloned packet is submitted to the egress pipeline for
-further processing.
+Packet cloning happens at the end of the ingress and/or egress
+pipeline. PSA specifies the following semantics for the clone
+operation.  When the clone operation is invoked at the end of the
+ingress pipeline, the cloned packet is a copy of the packet as it
+entered the ingress parser.  When the clone operation is invoked at
+the end of egress pipeline, the cloned packet is a copy of the
+modified packet after egress processing, as output by the egress
+deparser.  In both cases, the cloned packet is submitted to the egress
+pipeline for further processing.
 
-Logically, PRE implements the mechanics of copying a packet. PRE reads
-the original packet from ingress port and the modified packet from
-egress deparser. PRE then decides which version of the packet to use
-to generate a copy based on the value of the metadata provided by the
-ingress and egress pipeline.  The metadata fields that control cloning
-are those whose names begin with `clone` in types
-`psa_ingress_output_metadata_t` and `psa_egress_output_metadata_t`.
+Logically, PRE implements the mechanics of copying a packet.  PRE
+reads the original packet as it began ingress parsing, or the modified
+packet from the egress deparser.  PRE then decides which version of
+the packet to use to generate a copy based on the value of the
+metadata provided by the ingress and egress pipeline.  The metadata
+fields that control cloning are those whose names begin with `clone`
+in types `psa_ingress_output_metadata_t` and
+`psa_egress_output_metadata_t`.
+
+~ TBD
+The sentence beginning "PRE then decides which version of the packet
+to use to generate a copy" makes it sound like either you can create a
+clone of a packet in the ingress pipeline, or you can create a clone
+of a packet in the egress pipeline, but you cannot do both for the
+same packet.  The ingress and egress executions of packets, whether
+they occur due to the same original packet or different ones, are
+pretty much independent events, true?
+
+If so, it would be good to reword, or eliminate, that sentence and any
+text that could be misinterpreted in that way.
+~
 
 ```
 bool                     clone;
@@ -1045,8 +1076,8 @@ different actions as opposed to the ones used to process the original
 packet. Further, if a target permits the same packet to be resubmitted
 multiple times, the user program can distinguish the packet
 resubmitted the first time, or second time, by the extra metadata
-associated with the packet. Note the maximum number of packet
-resubmission for a single packet is target-dependent, see section
+associated with the packet.  Note the maximum number of packet
+resubmission for a single packet is target-dependent.  See section
 [#packet-paths].
 
 PSA specifies that the resubmit operation can only be used in the
@@ -1069,12 +1100,12 @@ resubmitted in the first pass with additional metadata to select one
 of the algorithms. Then, the resubmitted packet can be parsed,
 modified and deparsed using the selected algorithm.
 
-To facilitate communication between the first pass and the second pass
-through the ingress pipeline, the resubmission mechanism supports
-attaching optional metadata with the resubmitted packet. The metadata
-is generated during the first pass through the ingress pipeline, and
-used in the second pass. See Section [#sec-open-metadata] for the
-discussion.
+To facilitate communication from the ingress processing pass that
+caused a resubmit to occur, to the next ingress processing pass after
+the resubmit has happened, the resubmission mechanism supports
+attaching optional metadata with the resubmitted packet.  The metadata
+is generated during the pass through the ingress pipeline that chooses
+the resubmit operation, and used in the next pass.
 
 A PSA implementation provides a configuration bit `resubmit` to the
 PRE to enable the resubmission mechanism. If true, the original packet
@@ -1085,30 +1116,30 @@ resubmission mechanism is disabled and no assignments to
 
 ## Packet Recirculation {#sec-recirculate}
 
-Packet recirculation is a mechanism to repeat both ingress and egress
-processing on a packet.
+Packet recirculation is a mechanism to repeat ingress processing on a
+packet, after it has completed egress processing.  Unlike a resubmit,
+where the resubmitted packet contents are identical to the packet that
+arrived at the ingress parser, a recirculated packet may have
+different headers than the packet had before recirculation.  This
+could be useful in implementing features such as multiple levels of
+tunnel encapsulation or decapsulation.
 
-Packet recirculation happens at the end of the egress pipeline. When a
-packet is recirculated, the packet finishes both ingress and egress
-processing and re-enters the ingress parser after being deparsed by
-the egress deparser. The `ingress_port` of the recirculated packet is
-set to `PORT_RECIRCULATE`. The `packet_path` of the recirculated
-packet is changed to `RECIRCULATE`.
+Packet recirculation happens at the end of the egress pipeline, but
+whether a packet is recirculated must be chosen during ingress
+processing, by sending the packet to port `PORT_RECIRCULATE`.  When a
+packet is sent to the recirculate port, the packet finishes egress
+processing, including the egress deparser, and then re-enters the
+ingress parser.  The `ingress_port` of the recirculated packet is set
+to `PORT_RECIRCULATE`. The `packet_path` of the recirculated packet is
+set to `RECIRCULATE`.
 
 Similar to packet resubmission, packet recirculation also supports
-attaching optional metadata with the recirculated packet. The metadata
-is generated during the first pass through the ingress and egress
-pipeline, and used in the second pass. See Section
-[#sec-open-metadata] for the discussion.
+attaching optional metadata with the recirculated packet.  The
+metadata is generated during egress processing, and filled in by
+assigning a value to the `out` parameter `recirculate_meta` of the
+egress deparser.  The metadata is available to the ingress parser
+after the packet is recirculated.
 
-The `recirculate` flag specifies whether a packet should be
-recirculated and it is a read-only value in the egress deparser. The
-`recirculate` flag is set to true if the `egress_port` is set to
-`PORT_RECIRCULATE` in the ingress pipeline, otherwise, the flag is set
-to false. If the `recirculate` flag is true, the processed packet
-should be recirculated at the end of the egress pipeline with the
-optional metadata. If false, the recirculation mechanism is disabled
-and no assignments to `recirc_meta` should be performed.
 
 # PSA Externs
 
@@ -1231,8 +1262,14 @@ The PRE extern object has no constructor, and thus it cannot be
 instantiated in the user's P4 program. The architecture instantiates
 it exactly once, without requiring the user's P4 program to
 instantiate it. The PRE is made available to the `PSA_Switch` package.
-A corresponding Buffering and Queuing Engine (BQE) extern
-is defined for the egress pipeline (see [#sec-bqe]).
+
+~ TBD
+The statement "The PRE extern object has no constructor" is currently
+wrong.  We should either make it correct by changing psa.p4 somehow,
+or update the text above to match psa.p4.
+
+The same comment applies for the BQE section below.
+~
 
 
 ## Buffering Queuing Engine {#sec-bqe}
@@ -1249,6 +1286,7 @@ The BQE extern object has no constructor, and thus it cannot be
 instantiated in the user's P4 program. The architecture instantiates
 it exactly once, without requiring the user's P4 program to
 instantiate it. The BQE is made available to the `PSA_Switch` package.
+
 
 ## Hashes {#sec-hash-algorithms}
 
@@ -2199,26 +2237,6 @@ a common P4 program.
 
 We also need to formalize the interaction of action profiles and action selectors with counters and
 meters.
-
-## Metadata serialization {#sec-open-metadata}
-
-We have several proposals for serializing metadata that is bridged across the PRE between the
-ingress and egress pipelines, or as part of cloned and resubmitted packets. We are actively working
-on building a set of examples to determine what will be the final PSA API for these operations.
-
-~ TBD
-This section needs to be updated.
-~
-
-For the `clone_out` and `resubmit` externs, we are currently discussing the addition of a method,
-`add_metadata`, to enable prepending metadata to the cloned or resubmitted packet. It is
-the responsibility of the programmer to parse these packets such that it correctly extracts the
-attached metadata. The attached metadata may be of type `header`, `header stack`, `header union` or
-`struct` of the above types. Invoking the `add_metadata` method multiple times will attach all
-specified metadata to the same copy of the packet in the order in which the method was called. The
-PSA architecture instantiates the `clone_out` extern in the ingress and egress deparser. It is an
-error to instantiate the `clone_out` extern in blocks other than the deparser block.
-
 
 ## How does PSA interact with multiple pipelines
 

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -2456,8 +2456,8 @@ time", allows the egress processing to modify the packet further.
 
 2. Multicast efficiency and flexibility
 
-It is possible to handle multicast by doing a recirculate or resubmit
-operation in ingress processing for each of N copies to be made, but
+It is possible in a PSA device to handle multicast by doing a
+recirculate plus clone operation for each of N copies to be made, but
 this reduces the processing capacity of ingress that is available to
 newly arriving packets, in particular newly arriving packets that you
 might consider more important to keep than the multicast packets.
@@ -2465,16 +2465,16 @@ might consider more important to keep than the multicast packets.
 By designing a packet buffer that can take a packet with a 'multicast
 group id', which the control plane configures to make copies to a
 selected set of output ports, it frees up the part of the system that
-performs ingress processing to accept new packet more quickly, and at
+performs ingress processing to accept new packets more quickly, and at
 a more predictable rate.
 
 There could still be a challenge in designing the packet replication
 portion of the system not to fall behind when many multicast packets
 to be replicated to many output ports arrive close together in time,
 but it is fairly easy to separate the concerns of multicast from
-unicast packets.  For example, you could prioritize unicast packets so
-that they are not slowed down if multicast replication is falling
-behind.
+unicast packets.  For example, a device implementer could prioritize
+unicast packets so that they are not slowed down if multicast
+replication is falling behind.
 
 Once you have multicast designed in this way, there are still
 multicast use cases where one needs to process different copies of the

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -224,7 +224,9 @@ most common place in a P4 program where the output port(s) are chosen.
 The only exception to ingress choosing the output port is for
 egress-to-egress clone packets, whose destination port is chosen when
 the clone is created in the immediately preceding egress processing
-step.  See [#tbd] for the rationale for this restriction.
+step.  See section
+[#appendix-rationale-egress-cannot-change-output-port] for why this
+restriction exists.
 
 A single packet received by a PSA system from a port can result in 0,
 1, or many packets going out, all under control of the P4 program.
@@ -2410,3 +2412,138 @@ out of range includes:
   is implementation-defined (e.g. it might only be 1).  Extra
   information to identify which `count()` method call in the P4
   program had the out-of-range `index` value is also recommended.
+
+
+# Appendix: Rationale for design {#appendix-rationale}
+
+## Why egress processing? {#appendix-rationale-egress}
+
+Question: Why is it useful to have separate ingress vs. egress
+processing in a switch device?
+
+There have been packet processing ASICs built that effectively only do
+'ingress' processing, then go to a packet buffer with one or more
+queues, and then go out of the device, effectively being restricted to
+no or "empty" egress processing.
+
+There are a few things that are trickier to do in such a device.
+
+
+1. Last-nanosecond changes to the packet
+
+If you want to measure the queuing latency through the device, and put
+a measurement of this quantity inside the packet somewhere, it is in
+general not possible to know the queueing latency before the packet is
+sent to the packet buffer.  There are _special cases_ where you can
+predict it, e.g. when there is a single FIFO queue feeding a constant
+bit rate output port, with nothing like Ethernet pause flow control.
+
+But if you have variable bit rate links, e.g. because of things like
+Ethernet pause flow control, or Wi-Fi signal quality changes, or if
+you have multiple class-of-service queues with a scheduling policy
+between them like weighted fair queueing, then it is not possible to
+predict at the time the packet is enqueued, when it will be dequeued.
+The queueing latency depends upon unknown future events, such as
+whether Ethernet pause frames will arrive, or how many and what size
+of packets arriving in the near future will be put into which class of
+service queues for the same output port.
+
+In such cases, having egress processing for taking the measurement,
+after it is known and easy to calculate as "dequeue time - enqueue
+time", allows the egress processing to modify the packet further.
+
+
+
+2. Multicast efficiency and flexibility
+
+It is possible to handle multicast by doing a recirculate or resubmit
+operation in ingress processing for each of N copies to be made, but
+this reduces the processing capacity of ingress that is available to
+newly arriving packets, in particular newly arriving packets that you
+might consider more important to keep than the multicast packets.
+
+By designing a packet buffer that can take a packet with a 'multicast
+group id', which the control plane configures to make copies to a
+selected set of output ports, it frees up the part of the system that
+performs ingress processing to accept new packet more quickly, and at
+a more predictable rate.
+
+There could still be a challenge in designing the packet replication
+portion of the system not to fall behind when many multicast packets
+to be replicated to many output ports arrive close together in time,
+but it is fairly easy to separate the concerns of multicast from
+unicast packets.  For example, you could prioritize unicast packets so
+that they are not slowed down if multicast replication is falling
+behind.
+
+Once you have multicast designed in this way, there are still
+multicast use cases where one needs to process different copies of the
+packet differently.  For example, the copy going out port 5 might need
+a VLAN tag of 7 placed in its header, whereas the copy going out port
+2 might need a VLAN tag of 18 placed in its header.  Similarly for
+multicast packets entering one of many flavors of tunnels, e.g. VXLAN,
+GRE, etc.  By doing this per-copy modifications in egress processing,
+the packet replication logic can be kept very simple -- just make
+identical copies of the packet as ingress finished with it, except for
+some kind of unique 'id' on each copy that egress processing can use
+to distinguish them.
+
+
+## No output port change during egress {#appendix-rationale-egress-cannot-change-output-port}
+
+Question: Why can't my P4 program change the output port during egress
+processing?
+
+In a network device that has many input and output ports, packets can
+arrive at or near the same time on multiple input ports, all destined
+for the same output port.
+
+Packet buffers are typically designed into such network devices, to
+store the packets that cannot be sent out immediately, absorbing this
+short term congestion.
+
+For a given output port P, we now wish to retrieve packets from the
+packet buffer at a rate that is equal to the rate we will send them to
+port P, typically equal to the maximum bit rate that it is possible to
+send data out of port P.
+
+Packet scheduling algorithms such as weighted fair queueing, and many
+others, have been developed that can determine which among a set of
+potentially many FIFO queues that a packet should be read from next,
+and sent out on the port.
+
+These link scheduling algorithms are real time algorithms with very
+tight timing constraints.  If they go too slow, the output port goes
+idle and its capacity is wasted.  If they go too fast, we read packets
+from the packet buffer faster than they can be transmitted on the
+port, and we are back at the same problem we had originally -- either
+drop some of the packets, or store them somewhere again until the port
+is ready to transmit them.
+
+Such a scheduling algorithm that handles multiple output ports must
+know which output port all packets are destined to, before they are
+put into the packet buffer.  If that target output port can be changed
+after the packet is read out, then we can simultaneously overload one
+output port while starving another.
+
+That is why the `egress_port` of a packet must be selected during
+ingress processing, and egress processing is not allowed to change it.
+
+These scheduling algorithms also need to know the size of each packet,
+i.e. the size as it will be when transmitted on the port.
+
+It is possible in egress P4 code to drop a packet, or to change the
+size of the packet by adding or removing headers.  Very likely
+P4-programmable network devices will have their scheduling algorithms
+run just slightly faster than the port to handle cases where many
+packets in a row are decreased in size during egress processing, and
+have tight control loops monitoring the size of packets leaving egress
+processing to make small adustments in the rate that the scheduling
+algorithm operates for each port.  Either that, or they will just
+leave some fraction of the output port's capacity unused during times
+when all packet sizes are being decreased.
+
+Certainly if there are long durations of time when egress decides to
+drop all packets to an output port, that port will go idle.  The
+scheduling algorithm implementations are all built with a finite
+maximum packet scheduling rate.

--- a/p4-16/psa/examples/psa-example-bridged-metadata.p4
+++ b/p4-16/psa/examples/psa-example-bridged-metadata.p4
@@ -338,7 +338,8 @@ control EgressDeparserImpl(
     out recirculate_metadata_t recirculate_meta,
     inout headers hdr,
     in metadata meta,
-    in psa_egress_output_metadata_t istd)
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() common_deparser;
     apply {
@@ -352,7 +353,7 @@ control EgressDeparserImpl(
 
         // Assignments to the out parameter recirculate_meta must be
         // guarded by this if condition:
-        if (psa_recirculate(istd)) {
+        if (psa_recirculate(istd, edstd)) {
             recirculate_meta.my_meta2 = meta.my_meta2;
             recirculate_meta.my_meta3 = meta.my_meta3;
         }

--- a/p4-16/psa/examples/psa-example-clone-to-port.p4
+++ b/p4-16/psa/examples/psa-example-clone-to-port.p4
@@ -202,7 +202,8 @@ control EgressDeparserImpl(
     out empty_metadata_t recirculate_meta,
     inout headers hdr,
     in metadata meta,
-    in psa_egress_output_metadata_t istd)
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
 {
     DeparserImpl() common_deparser;
     apply {

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -205,7 +205,8 @@ control EgressDeparserImpl(
     out empty_metadata_t recirculate_meta,
     inout headers hdr,
     in metadata meta,
-    in psa_egress_output_metadata_t istd)
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() cp;
     apply {

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -214,6 +214,7 @@ control EgressDeparserImpl(
     }
 }
 
+// BEGIN:Package_Instantiation_Example
 IngressPipeline(IngressParserImpl(),
                 ingress(),
                 IngressDeparserImpl()) ip;
@@ -222,4 +223,5 @@ EgressPipeline(EgressParserImpl(),
                egress(),
                EgressDeparserImpl()) ep;
 
-PSA_SWITCH(ip, ep) main;
+PSA_Switch(ip, PacketReplicationEngine(), ep, BufferingQueueingEngine()) main;
+// END:Package_Instantiation_Example

--- a/p4-16/psa/examples/psa-example-digest.p4
+++ b/p4-16/psa/examples/psa-example-digest.p4
@@ -180,7 +180,8 @@ control EgressDeparserImpl(packet_out packet,
                            clone_out cl,
                            inout headers hdr,
                            in metadata meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() common_deparser;
     apply {

--- a/p4-16/psa/examples/psa-example-incremental-checksum.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum.p4
@@ -181,7 +181,8 @@ control EgressDeparserImpl(packet_out packet,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata user_meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     InternetChecksum() ck;
     apply {

--- a/p4-16/psa/examples/psa-example-incremental-checksum2.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum2.p4
@@ -365,7 +365,8 @@ control EgressDeparserImpl(packet_out packet,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata user_meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     InternetChecksum() ck;
     apply {

--- a/p4-16/psa/examples/psa-example-mirror-on-drop.p4
+++ b/p4-16/psa/examples/psa-example-mirror-on-drop.p4
@@ -206,7 +206,9 @@ control EgressDeparserImpl(packet_out packet,
     clone_out clone,
     inout headers hdr,
     in userMetadata meta,
-    in psa_egress_output_metadata_t istd) {
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
+{
     DeparserImpl() common_deparser;
     apply {
         if (istd.clone) {

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -233,7 +233,8 @@ control EgressDeparserImpl(packet_out packet,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     InternetChecksum() ck;
     apply {

--- a/p4-16/psa/examples/psa-example-recirculate.p4
+++ b/p4-16/psa/examples/psa-example-recirculate.p4
@@ -1,4 +1,3 @@
-
 /*
 Copyright 2017 Barefoot Networks, Inc.
 
@@ -102,6 +101,12 @@ parser IngressParserImpl(
 
     state parse_recirc_header {
         user_meta.recirc_header = recirc_meta;
+        // @hanw - You could write a P4 program like this, but then
+        // recirculated packets would have no headers parsed and valid
+        // during ingress processing, true?  It seems like a much
+        // better and more typical example if we use 'transition
+        // parse_ethernet' instead of 'transition accept' on the next
+        // line.  Do you agree?
 	transition accept;
     }
 
@@ -186,12 +191,13 @@ control EgressDeparserImpl(
     out recirc_metadata_t recirc_meta,
     inout headers hdr,
     in metadata meta,
-    in psa_egress_output_metadata_t istd)
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
 {
     DeparserImpl() common_deparser;
     apply {
-        if (psa_recirculate(istd)) {
-            recirc_meta.custom_field = 8w1;
+        if (psa_recirculate(istd, edstd)) {
+            recirc_meta.custom_field = 1;
         }
         common_deparser.apply(packet, hdr);
     }

--- a/p4-16/psa/examples/psa-example-recirculate.p4
+++ b/p4-16/psa/examples/psa-example-recirculate.p4
@@ -94,20 +94,14 @@ parser IngressParserImpl(
 
     state start {
         transition select(istd.packet_path) {
-           PacketPath_t.RECIRCULATE: parse_recirc_header;
+           PacketPath_t.RECIRCULATE: copy_recirc_meta;
            PacketPath_t.NORMAL: parse_ethernet;
         }
     }
 
-    state parse_recirc_header {
+    state copy_recirc_meta {
         user_meta.recirc_header = recirc_meta;
-        // @hanw - You could write a P4 program like this, but then
-        // recirculated packets would have no headers parsed and valid
-        // during ingress processing, true?  It seems like a much
-        // better and more typical example if we use 'transition
-        // parse_ethernet' instead of 'transition accept' on the next
-        // line.  Do you agree?
-	transition accept;
+	transition parse_ethernet;
     }
 
     state parse_ethernet {

--- a/p4-16/psa/examples/psa-example-register1.p4
+++ b/p4-16/psa/examples/psa-example-register1.p4
@@ -172,7 +172,8 @@ control EgressDeparserImpl(packet_out buffer,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() cp;
     apply {

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -181,7 +181,8 @@ control EgressDeparserImpl(packet_out buffer,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() cp;
     apply {

--- a/p4-16/psa/examples/psa-example-resubmit.p4
+++ b/p4-16/psa/examples/psa-example-resubmit.p4
@@ -157,7 +157,7 @@ parser EgressParserImpl(
     out headers parsed_hdr,
     inout metadata user_meta,
     in psa_egress_parser_input_metadata_t istd,
-    in metadata normal_meta,
+    in empty_metadata_t normal_meta,
     in empty_metadata_t clone_i2e_meta,
     in empty_metadata_t clone_e2e_meta,
     out psa_parser_output_metadata_t ostd)
@@ -189,7 +189,7 @@ control IngressDeparserImpl(
     packet_out packet,
     out empty_metadata_t clone_i2e_meta,
     out resubmit_metadata_t resubmit_meta,
-    out metadata normal_meta,
+    out empty_metadata_t normal_meta,
     inout headers hdr,
     in metadata meta,
     in psa_ingress_output_metadata_t istd)

--- a/p4-16/psa/examples/psa-example-resubmit.p4
+++ b/p4-16/psa/examples/psa-example-resubmit.p4
@@ -50,18 +50,20 @@ header header_b_t {
 }
 
 // BEGIN:Resubmit_Example_Part1
-header resubmit_metadata_t {
+struct resubmit_metadata_t {
     bit<8> selector;
+    header_a_t header_a;
+    header_b_t header_b;
 }
 // END:Resubmit_Example_Part1
+
+struct empty_metadata_t {}
 
 struct fwd_metadata_t {
     bit<9> output_port;
 }
 
 struct metadata {
-    header_a_t header_a;
-    header_b_t header_b;
     resubmit_metadata_t resubmit_meta;
     fwd_metadata_t fwd_meta;
 }
@@ -91,51 +93,31 @@ parser CommonParser(packet_in buffer,
     }
 }
 
-parser ResubmitParser(packet_in buffer,
-    in psa_ingress_parser_input_metadata_t istd,
-    inout metadata user_meta)
-{
-    state start {
-        buffer.extract(user_meta.resubmit_meta);
-        transition select(user_meta.resubmit_meta.selector) {
-            8w1 : parse_header_a;
-            8w2 : parse_header_b;
-            default: reject;
-        }
-    }
-    state parse_header_a {
-        buffer.extract(user_meta.header_a);
-        transition accept;
-    }
-    state parse_header_b {
-        buffer.extract(user_meta.header_b);
-        transition accept;
-    }
-}
-
-parser IngressParserImpl(packet_in buffer,
+parser IngressParserImpl(
+    packet_in buffer,
     out headers parsed_hdr,
     inout metadata user_meta,
     in psa_ingress_parser_input_metadata_t istd,
+    in resubmit_metadata_t resub_meta,
+    in empty_metadata_t recirculate_meta,
     out psa_parser_output_metadata_t ostd)
 {
     CommonParser() cp;
-    ResubmitParser() rp;
 
     state start {
         transition select(istd.packet_path) {
-           PacketPath_t.RESUBMIT: parse_resubmit;
-           PacketPath_t.NORMAL: parse_ethernet;
+           PacketPath_t.RESUBMIT: copy_resubmit_meta;
+           PacketPath_t.NORMAL: packet_in_parsing;
         }
     }
 
-    state parse_ethernet {
-        cp.apply(buffer, parsed_hdr, user_meta);
-        transition accept;
+    state copy_resubmit_meta {
+        user_meta.resubmit_meta = resub_meta;
+        transition packet_in_parsing;
     }
 
-    state parse_resubmit {
-        rp.apply(buffer, istd, user_meta);
+    state packet_in_parsing {
+        cp.apply(buffer, parsed_hdr, user_meta);
         transition accept;
     }
 }
@@ -157,15 +139,27 @@ control ingress(inout headers hdr,
     }
 
     apply {
+        // Note that this example will resubmit all input packets
+        // forever, until and unless the PSA implementation drops
+        // them.
         t.apply();
+
+        // Note: For a more complete example, there should be
+        // assignments to meta.resubmit_meta.selector, and the
+        // appropriate one of meta.resubmit_meta.header_a or
+        // meta.resubmit_meta.header_b
     }
 }
 // END:Resubmit_Example_Part2
 
-parser EgressParserImpl(packet_in buffer,
+parser EgressParserImpl(
+    packet_in buffer,
     out headers parsed_hdr,
     inout metadata user_meta,
     in psa_egress_parser_input_metadata_t istd,
+    in metadata normal_meta,
+    in empty_metadata_t clone_i2e_meta,
+    in empty_metadata_t clone_e2e_meta,
     out psa_parser_output_metadata_t ostd)
 {
     CommonParser() cp;
@@ -183,33 +177,46 @@ control egress(inout headers hdr,
     apply { }
 }
 
-control DeparserImpl(packet_out packet, inout headers hdr) {
-    apply { }
-}
-
-// BEGIN:Resubmit_Example_Part3
-control IngressDeparserImpl(packet_out packet,
-    clone_out clone,
-    inout headers hdr,
-    in metadata meta,
-    in psa_ingress_output_metadata_t istd)
-{
-    DeparserImpl() common_deparser;
+control CommonDeparserImpl(packet_out packet, inout headers hdr) {
     apply {
-        common_deparser.apply(packet, hdr);
         packet.emit(hdr.ethernet);
         packet.emit(hdr.ipv4);
     }
 }
-// END:Resubmit_Example_Part3
 
-control EgressDeparserImpl(packet_out packet,
-    clone_out cl,
+// BEGIN:Resubmit_Example_Part3
+control IngressDeparserImpl(
+    packet_out packet,
+    out empty_metadata_t clone_i2e_meta,
+    out resubmit_metadata_t resubmit_meta,
+    out metadata normal_meta,
     inout headers hdr,
     in metadata meta,
-    in psa_egress_output_metadata_t istd)
+    in psa_ingress_output_metadata_t istd)
 {
-    DeparserImpl() common_deparser;
+    CommonDeparserImpl() common_deparser;
+    apply {
+        // Assignments to the out parameter resubmit_meta must be
+        // guarded by this if condition:
+        if (psa_resubmit(istd)) {
+            resubmit_meta = meta.resubmit_meta;
+        }
+
+        common_deparser.apply(packet, hdr);
+    }
+}
+// END:Resubmit_Example_Part3
+
+control EgressDeparserImpl(
+    packet_out packet,
+    out empty_metadata_t clone_e2e_meta,
+    out empty_metadata_t recirculate_meta,
+    inout headers hdr,
+    in metadata meta,
+    in psa_egress_output_metadata_t istd,
+    in psa_egress_deparser_input_metadata_t edstd)
+{
+    CommonDeparserImpl() common_deparser;
     apply {
         common_deparser.apply(packet, hdr);
     }

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -166,7 +166,8 @@ control EgressDeparserImpl(packet_out buffer,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() cp;
     apply {

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -161,7 +161,8 @@ control EgressDeparserImpl(packet_out buffer,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() cp;
     apply {

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -168,7 +168,8 @@ control EgressDeparserImpl(packet_out buffer,
                            out empty_metadata_t recirculate_meta,
                            inout headers hdr,
                            in metadata meta,
-                           in psa_egress_output_metadata_t istd)
+                           in psa_egress_output_metadata_t istd,
+                           in psa_egress_deparser_input_metadata_t edstd)
 {
     CommonDeparserImpl() cp;
     apply {


### PR DESCRIPTION
Changes include:

+ Eliminate recirculate and resubmit extern objects from psa.p4.
+ Proposed addition of a new struct that contains only egress_port field, to be given as 'in' parameter to the egress deparser, so it can distinguish between recirculated packets vs. others.  It something like this to implement psa_recirculate() function correctly.  This is one of several ways to do it, but we could choose something else.
+ Many small changes to PSA.mdk mentioning things about recirculate, and updating them to the current planned way to do it.
+ A few other small corrections and occurrences of rewording that I hope are improvements in PSA.mdk.