### PR TITLE
Remove unnecessary psa_parser_output_metadata_t struct

### DIFF
--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -20,7 +20,8 @@ clean:
 # regularly occur with these example programs for the 'out
 # psa_parser_output_metadata_t ostd' parameter of the parsers.
 
-P4C=p4test --Wdisable=uninitialized_out_param
+P4C=p4test
+#P4C=p4test --Wdisable=uninitialized_out_param
 
 check:
 	${P4C} examples/psa-example-bridged-metadata.p4

--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -358,8 +358,8 @@ packet contents and metadata when a packet begins ingress processing.
 |                     | For RESUB or RECIRC packets, the time the 'copy'    ||||
 |                     | began IngressParser, not the original.              ||||
 +--------------+-------------+---------------+--------------+-----+
-| `parser_error`      | From output of IngressParser.  Always `error.NoError` if there ||||
-|                     | was no parser error.                                           ||||
+| `parser_error`      | From IngressParser.  Always `error.NoError` if there ||||
+|                     | was no parser error.                                 ||||
 |--------------|-------------|---------------|--------------|-----|
 ~
 
@@ -765,8 +765,8 @@ packet contents and metadata when a packet begins egress processing.
 | `egress_timestamp` | Time that packet began processing in EgressParser.  Filled in ||||
 |                     | independently for each copy of a multicast-replicated packet. ||||
 +--------------+-------------+---------------+--------------+-----+
-| `parser_error`    | From output of EgressParser.  Always `error.NoError` if there ||||
-|                   | was no parser error.  See "Multicast copies" section.         ||||
+| `parser_error`    | From EgressParser.  Always `error.NoError` if there   ||||
+|                   | was no parser error.  See "Multicast copies" section. ||||
 |--------------|-------------|---------------|--------------|-----|
 ~
 

--- a/p4-16/psa/examples/psa-example-bridged-metadata.p4
+++ b/p4-16/psa/examples/psa-example-bridged-metadata.p4
@@ -171,8 +171,7 @@ parser IngressParserImpl(
     inout metadata meta,
     in psa_ingress_parser_input_metadata_t istd,
     in resubmit_metadata_t resubmit_meta,
-    in recirculate_metadata_t recirculate_meta,
-    out psa_parser_output_metadata_t ostd)
+    in recirculate_metadata_t recirculate_meta)
 {
     CommonParser() p;
 
@@ -208,8 +207,7 @@ parser EgressParserImpl(
     in psa_egress_parser_input_metadata_t istd,
     in metadata normal_meta,
     in clone_i2e_metadata_t clone_i2e_meta,
-    in clone_e2e_metadata_t clone_e2e_meta,
-    out psa_parser_output_metadata_t ostd)
+    in clone_e2e_metadata_t clone_e2e_meta)
 {
     CommonParser() p;
 

--- a/p4-16/psa/examples/psa-example-clone-to-port.p4
+++ b/p4-16/psa/examples/psa-example-clone-to-port.p4
@@ -91,8 +91,7 @@ parser IngressParserImpl(
     inout metadata user_meta,
     in psa_ingress_parser_input_metadata_t istd,
     in empty_metadata_t resubmit_meta,
-    in empty_metadata_t recirculate_meta,
-    out psa_parser_output_metadata_t ostd)
+    in empty_metadata_t recirculate_meta)
 {
     CommonParser() p;
 
@@ -133,8 +132,7 @@ parser EgressParserImpl(
     in psa_egress_parser_input_metadata_t istd,
     in metadata normal_meta,
     in clone_i2e_metadata_t clone_i2e_meta,
-    in empty_metadata_t clone_e2e_meta,
-    out psa_parser_output_metadata_t ostd)
+    in empty_metadata_t clone_e2e_meta)
 {
     CommonParser() p;
 

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -90,8 +90,7 @@ parser IngressParserImpl(
     inout metadata user_meta,
     in psa_ingress_parser_input_metadata_t istd,
     in empty_metadata_t resubmit_meta,
-    in empty_metadata_t recirculate_meta,
-    out psa_parser_output_metadata_t ostd)
+    in empty_metadata_t recirculate_meta)
 {
     CommonParser() p;
 
@@ -108,8 +107,7 @@ parser EgressParserImpl(
     in psa_egress_parser_input_metadata_t istd,
     in empty_metadata_t normal_meta,
     in empty_metadata_t clone_i2e_meta,
-    in empty_metadata_t clone_e2e_meta,
-    out psa_parser_output_metadata_t ostd)
+    in empty_metadata_t clone_e2e_meta)
 {
     CommonParser() p;
 

--- a/p4-16/psa/examples/psa-example-digest.p4
+++ b/p4-16/psa/examples/psa-example-digest.p4
@@ -91,8 +91,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     CommonParser() p;
 
@@ -112,8 +111,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     CommonParser() p;
 

--- a/p4-16/psa/examples/psa-example-incremental-checksum.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum.p4
@@ -86,8 +86,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     state start {
         buffer.extract(parsed_hdr.ethernet);
@@ -144,8 +143,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/examples/psa-example-incremental-checksum2.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum2.p4
@@ -106,8 +106,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     InternetChecksum() ck;
 
@@ -326,8 +325,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/examples/psa-example-mirror-on-drop.p4
+++ b/p4-16/psa/examples/psa-example-mirror-on-drop.p4
@@ -102,8 +102,7 @@ parser CloneParser(packet_in buffer,
 parser IngressParserImpl(packet_in buffer,
                          out headers parsed_hdr,
                          inout metadata user_meta,
-                         in psa_ingress_parser_input_metadata_t istd,
-                         out psa_parser_output_metadata_t ostd)
+                         in psa_ingress_parser_input_metadata_t istd)
 {
     CommonParser() p;
     CloneParser() cp;
@@ -155,8 +154,7 @@ control ingress(inout headers hdr,
 parser EgressParserImpl(packet_in buffer,
                         out headers parsed_hdr,
                         inout metadata user_meta,
-                        in psa_egress_parser_input_metadata_t istd,
-                        out psa_parser_output_metadata_t ostd)
+                        in psa_egress_parser_input_metadata_t istd)
 {
     CommonParser() p;
 

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -90,8 +90,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     InternetChecksum() ck;
     state start {
@@ -196,8 +195,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/examples/psa-example-recirculate.p4
+++ b/p4-16/psa/examples/psa-example-recirculate.p4
@@ -87,8 +87,7 @@ parser IngressParserImpl(
     inout metadata user_meta,
     in psa_ingress_parser_input_metadata_t istd,
     in empty_metadata_t resub_meta,
-    in recirc_metadata_t recirc_meta,
-    out psa_parser_output_metadata_t ostd)
+    in recirc_metadata_t recirc_meta)
 {
     CommonParser() p;
 
@@ -137,8 +136,7 @@ parser EgressParserImpl(
     in psa_egress_parser_input_metadata_t istd,
     in empty_metadata_t normal_meta,
     in empty_metadata_t clone_i2e_meta,
-    in empty_metadata_t cloen_e2e_meta,
-    out psa_parser_output_metadata_t ostd)
+    in empty_metadata_t cloen_e2e_meta)
 {
     CommonParser() p;
 

--- a/p4-16/psa/examples/psa-example-register1.p4
+++ b/p4-16/psa/examples/psa-example-register1.p4
@@ -80,8 +80,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     state start {
         transition parse_ethernet;
@@ -128,8 +127,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -89,8 +89,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     state start {
         transition parse_ethernet;
@@ -137,8 +136,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/examples/psa-example-resubmit.p4
+++ b/p4-16/psa/examples/psa-example-resubmit.p4
@@ -99,8 +99,7 @@ parser IngressParserImpl(
     inout metadata user_meta,
     in psa_ingress_parser_input_metadata_t istd,
     in resubmit_metadata_t resub_meta,
-    in empty_metadata_t recirculate_meta,
-    out psa_parser_output_metadata_t ostd)
+    in empty_metadata_t recirculate_meta)
 {
     CommonParser() cp;
 
@@ -159,8 +158,7 @@ parser EgressParserImpl(
     in psa_egress_parser_input_metadata_t istd,
     in empty_metadata_t normal_meta,
     in empty_metadata_t clone_i2e_meta,
-    in empty_metadata_t clone_e2e_meta,
-    out psa_parser_output_metadata_t ostd)
+    in empty_metadata_t clone_e2e_meta)
 {
     CommonParser() cp;
     state start {

--- a/p4-16/psa/examples/psa-example-value-sets.p4
+++ b/p4-16/psa/examples/psa-example-value-sets.p4
@@ -62,8 +62,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     ValueSet<bit<16>>(4) tpid_types;
     ValueSet<bit<16>>(2) trill_types;
@@ -122,8 +121,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/examples/psa-example-value-sets2.p4
+++ b/p4-16/psa/examples/psa-example-value-sets2.p4
@@ -61,8 +61,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     ValueSet<bit<16>>(4) tpid_types;
     ValueSet<bit<16>>(2) trill_types;
@@ -117,8 +116,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/examples/psa-example-value-sets3.p4
+++ b/p4-16/psa/examples/psa-example-value-sets3.p4
@@ -67,8 +67,7 @@ parser IngressParserImpl(packet_in buffer,
                          inout metadata user_meta,
                          in psa_ingress_parser_input_metadata_t istd,
                          in empty_metadata_t resubmit_meta,
-                         in empty_metadata_t recirculate_meta,
-                         out psa_parser_output_metadata_t ostd)
+                         in empty_metadata_t recirculate_meta)
 {
     ValueSet<CustomValueSet1_t>(2) trill_types;
 
@@ -124,8 +123,7 @@ parser EgressParserImpl(packet_in buffer,
                         in psa_egress_parser_input_metadata_t istd,
                         in empty_metadata_t normal_meta,
                         in empty_metadata_t clone_i2e_meta,
-                        in empty_metadata_t clone_e2e_meta,
-                        out psa_parser_output_metadata_t ostd)
+                        in empty_metadata_t clone_e2e_meta)
 {
     state start {
         transition accept;

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -88,10 +88,6 @@ struct psa_egress_parser_input_metadata_t {
   PacketPath_t             packet_path;
 }
 
-struct psa_parser_output_metadata_t {
-  ParserError_t            parser_error;
-}
-
 struct psa_ingress_input_metadata_t {
   // All of these values are initialized by the architecture before
   // the Ingress control block begins executing.
@@ -618,8 +614,7 @@ parser IngressParser<H, M, RESUBM, RECIRCM>(
     inout M user_meta,
     in psa_ingress_parser_input_metadata_t istd,
     in RESUBM resubmit_meta,
-    in RECIRCM recirculate_meta,
-    out psa_parser_output_metadata_t ostd);
+    in RECIRCM recirculate_meta);
 
 control Ingress<H, M>(
     inout H hdr, inout M user_meta,
@@ -642,8 +637,7 @@ parser EgressParser<H, M, NM, CI2EM, CE2EM>(
     in psa_egress_parser_input_metadata_t istd,
     in NM normal_meta,
     in CI2EM clone_i2e_meta,
-    in CE2EM clone_e2e_meta,
-    out psa_parser_output_metadata_t ostd);
+    in CE2EM clone_e2e_meta);
 
 control Egress<H, M>(
     inout H hdr, inout M user_meta,


### PR DESCRIPTION
The only reason it was there was to carry the parser error out of the
ingress and egress parsers, but the PSA architecture can just
transport those parser errors to the ingress and egress control blocks
'somehow' by however the architecture does it, without making it an
'out' parameter of the parsers.

Note that the example architecture in the P4_16 language specification
does the same thing.