### PR TITLE
PSA Remove duplicate Madoko include tags

### DIFF
--- a/p4-16/psa/examples/psa-example-parser-error-handling.p4
+++ b/p4-16/psa/examples/psa-example-parser-error-handling.p4
@@ -243,7 +243,6 @@ control packet_path_to_bits(out bit<3> packet_path_bits,
 }
 
 
-// BEGIN:Parse_Error_Example
 // Define additional error values, one of them for packets with
 // incorrect IPv4 header checksums.
 error {
@@ -406,7 +405,6 @@ control ingress(inout headers hdr,
         // Do normal packet processing here.
     }
 }
-// END:Parse_Error_Example
 
 control CommonDeparserImpl(packet_out packet, inout headers hdr) {
     InternetChecksum() ck;


### PR DESCRIPTION
Madoko gives a warning message, I believe the condition in this
situation causing it is: if there are multiple files in INCLUDE
directives with the same name/id after BEGIN/END, then the warning
occurs.

The warning goes away when I delete these two lines.  PSA.mdk only
uses this name to INCLUDE a sample of code from the file
examples/psa-example-parser-checksum.p4, not
examples/psa-example-parser-error-handling.p4, so remove the
occurrence that we do not use or need.