### PR TITLE
Application of suggestion #633

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6737,18 +6737,23 @@ annotations
 
 annotation
     : '@' name
-    | '@' name '(' expressionList ')'
-    | '@' name '(' keyValueList ')'
+    | '@' name '(' argumentList ')'
     ;
 ...
-keyValuePair
-    : IDENTIFIER '=' expression
+argumentList
+    : /* empty */
+    | nonEmptyArgList
     ;
 
-keyValueList
-    : /* empty */
-    | keyValuePair
-    | keyValueList ',' keyValuePair
+nonEmptyArgList
+    : argument
+    | nonEmptyArgList ',' argument
+    ;
+
+argument
+    : expression          /* positional argument to the annotation */
+    | name '=' expression /* key-value pair for the annotation */
+    | DONTCARE
     ;
 ~ End P4Grammar
 

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -546,16 +546,6 @@ expressionList
     | expressionList ',' expression
     ;
 
-keyValuePair
-    : IDENTIFIER '=' expression
-    ;
-
-keyValueList
-    : /* empty */
-    | keyValuePair
-    | keyValueList ',' keyValuePair
-    ;
-
 member
     : name
     ;

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -43,8 +43,7 @@ annotations
 
 annotation
     : '@' name
-    | '@' name '(' expressionList ')'
-    | '@' name '(' keyValueList ')'
+    | '@' name '(' argumentList ')'
     ;
 
 parameterList


### PR DESCRIPTION
This Pull request offers a solution for issue #633 .

If annotations take argumentList instead
of either expressionList or keyValueList,
the exact same behavior is acheivable,
but without introducing ambiguity into the grammar.