### PR TITLE
Allow optional type parameters to be any name, and not just nonTypeName

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2528,8 +2528,8 @@ optTypeParameters
     ;
 
 typeParameterList
-    : nonTypeName
-    | typeParameterList ',' nonTypeName
+    : name
+    | typeParameterList ',' name
     ;
 ~ End P4Grammar
 

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -290,8 +290,8 @@ optTypeParameters
     ;
 
 typeParameterList
-    : nonTypeName
-    | typeParameterList ',' nonTypeName
+    : name
+    | typeParameterList ',' name
     ;
 
 typeArg


### PR DESCRIPTION
This introduces into the grammar the suggestion #635 .
In the compiler, it is already the case that suggestion #635 is implemented.