### PR TITLE
Require keyValueList to be non-empty

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6746,8 +6746,7 @@ keyValuePair
     ;
 
 keyValueList
-    : /* empty */
-    | keyValuePair
+    : keyValuePair
     | keyValueList ',' keyValuePair
     ;
 ~ End P4Grammar

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -552,8 +552,7 @@ keyValuePair
     ;
 
 keyValueList
-    : /* empty */
-    | keyValuePair
+    : keyValuePair
     | keyValueList ',' keyValuePair
     ;
 


### PR DESCRIPTION
If expressionList and keyValueList can both be empty,
then the grammar is ambiguous, since an annotations with
parenthesis but no arguments inside could either correspond
to an annotation with an empty expressionList or an annnotation with
an empty keyValueList.

The change suggested by this commit matches the
actual current implementation of the P4 compiler, and follows a suggestion by @mbudiu-vmw on pr #634 about suggestion #633 . 