### PR TITLE
Fix: add value sets to grammar

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5211,6 +5211,18 @@ Value sets are declared locally within a parser. They should be declared before
 being referenced in parser `keysetExpression` and can be used as a label in a
 select expression.
 
+The syntax for declaring value sets is:
+
+~ Begin P4Grammar
+valueSetDeclaration
+  : optAnnotations
+      VALUESET "<" baseType ">" "(" expression ")" name ";"
+  | optAnnotations
+      VALUESET "<" tupleType ">" "(" expression ")" name ";"
+  | optAnnotations
+      VALUESET "<" typeName ">" "(" expression ")" name ";"
+~ End P4Grammar
+
 Parser Value Sets support a `size` argument to provide hints to the compiler to
 reserve hardware resource to implement the value set. For example, this parser
 value set:

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -105,6 +105,7 @@ parserLocalElement
     : constantDeclaration
     | variableDeclaration
     | instantiation
+    | valueSetDeclaration
     ;
 
 parserTypeDeclaration
@@ -181,6 +182,14 @@ simpleKeysetExpression
     | expression MASK expression
     | expression RANGE expression
     ;
+
+valueSetDeclaration
+  : optAnnotations
+      VALUESET "<" baseType ">" "(" expression ")" name ";"
+  | optAnnotations
+      VALUESET "<" tupleType ">" "(" expression ")" name ";"
+  | optAnnotations
+      VALUESET "<" typeName ">" "(" expression ")" name ";"
 
 /*************************** CONTROL ************************/
 


### PR DESCRIPTION
+ Added into the grammar the rule for valueSetDeclaration (was missing).
+ Added to the spec text a quote of the valueSetDeclaration rule (optional).