### PR TITLE
Change double quotes into single quotes for consistency.

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5216,11 +5216,11 @@ The syntax for declaring value sets is:
 ~ Begin P4Grammar
 valueSetDeclaration
   : optAnnotations
-      VALUESET "<" baseType ">" "(" expression ")" name ";"
+      VALUESET '<' baseType '>' '(' expression ')' name ';'
   | optAnnotations
-      VALUESET "<" tupleType ">" "(" expression ")" name ";"
+      VALUESET '<' tupleType '>' '(' expression ')' name ';'
   | optAnnotations
-      VALUESET "<" typeName ">" "(" expression ")" name ";"
+      VALUESET '<' typeName '>' '(' expression ')' name ';'
 ~ End P4Grammar
 
 Parser Value Sets support a `size` argument to provide hints to the compiler to

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -185,11 +185,11 @@ simpleKeysetExpression
 
 valueSetDeclaration
   : optAnnotations
-      VALUESET "<" baseType ">" "(" expression ")" name ";"
+      VALUESET '<' baseType '>' '(' expression ')' name ';'
   | optAnnotations
-      VALUESET "<" tupleType ">" "(" expression ")" name ";"
+      VALUESET '<' tupleType '>' '(' expression ')' name ';'
   | optAnnotations
-      VALUESET "<" typeName ">" "(" expression ")" name ";"
+      VALUESET '<' typeName '>' '(' expression ')' name ';'
 
 /*************************** CONTROL ************************/
 


### PR DESCRIPTION
As pointed out by @mbudiu-vmw
everywhere else in the grammar, the quotes are single.