### PR TITLE
Corrected token involved in newtype declarations in the spec description

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2703,8 +2703,8 @@ Similarly to `typedef`, the keyword `type` can be used to introduce a
 new type.
 
 ~ Begin P4Grammar
-    | optAnnotations TYPE_IDENTIFIER typeRef name
-    | optAnnotations TYPE_IDENTIFIER derivedTypeDeclaration name
+    | optAnnotations TYPE typeRef name
+    | optAnnotations TYPE derivedTypeDeclaration name
 ~ End P4Grammar
 
 ~ Begin P4Example


### PR DESCRIPTION
This is a bugfix.
In the spec, in the description of newtype declarations, the grammar extract was wrong, as it did not use the correct token ( `TYPE_IDENTIFIER` was used instead of `TYPE` ).

The corresponding section in the grammar has not the same bug.