### PR TITLE
Removed parser actions from grammar

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2070,8 +2070,8 @@ typeRef
     ;
 
 namedType
-    : typeName                         { $$ = $1; }
-    | specializedType                  { $$ = $1; }
+    : typeName
+    | specializedType
     ;
 
 prefixedType

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -253,8 +253,8 @@ typeRef
     ;
 
 namedType
-    : typeName                         { $$ = $1; }
-    | specializedType                  { $$ = $1; }
+    : typeName
+    | specializedType
     ;
 
 prefixedType


### PR DESCRIPTION
There where some parser actions left in the grammar and in a grammar extract in the spec; removed them.