### PR TITLE
Use dotPrefix non terminal for toplevel paths in expressions

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2750,7 +2750,7 @@ expression
     | FALSE
     | STRING_LITERAL
     | nonTypeName
-    | '.' nonTypeName
+    | dotPrefix nonTypeName
     | expression '[' expression ']'
     | expression '[' expression ':' expression ']'
     | '{' expressionList '}'

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -609,7 +609,7 @@ expression
     | FALSE
     | STRING_LITERAL
     | nonTypeName
-    | '.' nonTypeName
+    | dotPrefix nonTypeName
     | expression '[' expression ']'
     | expression '[' expression ':' expression ']'
     | '{' expressionList '}'


### PR DESCRIPTION
This was already the case for all other toplevel paths, so this modification adds consistency.

As dotPrefix is, in the grammar, an alias of '.' , this doesn't change at all the set of syntactically correct programs.