### PR TITLE
Extend grammar extract for function declarations in the spec

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4155,6 +4155,10 @@ however, the language does not permit recursive functions.
 functionDeclaration
     : functionPrototype blockStatement
     ;
+
+functionPrototype
+    : typeOrVoid name optTypeParameters '(' parameterList ')'
+    ;
 ~ End P4Grammar
 
 Here is an example of a function that returns the maximum of two 32-bit values:


### PR DESCRIPTION
As the rule for declaring functions uses the functionPrototype
rule, I find it more clear to include the definition of functionPrototype
in the same extract.
What do you think?

(This is a very small modification, just for more clarity in the spec document)