### PR TITLE
TypeArg can be nonTypeName, because of the return type of externs

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2782,7 +2782,7 @@ expression
     | expression AND expression      // AND is &&
     | expression OR expression       // OR is ||
     | expression '?' expression ':' expression
-    | expression '<' typeArgumentList '>' '(' argumentList ')'
+    | expression '<' realTypeArgumentList '>' '(' argumentList ')'
     | expression '(' argumentList ')'
     | namedType '(' argumentList ')'
     | '(' typeRef ')' expression
@@ -2815,6 +2815,7 @@ argument
 typeArg
     : DONTCARE
     | typeRef
+    | nonTypeName
     ;
 
 typeArgumentList
@@ -4031,7 +4032,7 @@ following syntax:
 ~ Begin P4Grammar
 expression
     : ...
-    | expression '<' typeArgumentList '>' '(' argumentList ')'
+    | expression '<' realTypeArgumentList '>' '(' argumentList ')'
     | expression '(' argumentList ')'
 
 argumentList
@@ -4050,9 +4051,14 @@ argument
     | DONTCARE
     ;
 
-typeArgumentList
-    : typeRef
-    | typeArgumentList ',' typeRef
+realTypeArgumentList
+    : realTypeArg
+    | realTypeArgumentList ',' typeArg
+    ;
+
+realTypeArg
+    : DONTCARE
+    | typeRef
     ;
 ~ End P4Grammar
 

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -305,9 +305,20 @@ typeParameterList
     | typeParameterList ',' name
     ;
 
+realTypeArg
+    : DONTCARE
+    | typeRef
+    ;
+
 typeArg
     : DONTCARE
     | typeRef
+    | nonTypeName
+    ;
+
+realTypeArgumentList
+    : realTypeArg
+    | realTypeArgumentList COMMA typeArg
     ;
 
 typeArgumentList
@@ -643,7 +654,7 @@ expression
     | expression AND expression        // &&
     | expression OR expression         // ||
     | expression '?' expression ':' expression
-    | expression '<' typeArgumentList '>' '(' argumentList ')'
+    | expression '<' realTypeArgumentList '>' '(' argumentList ')'
     | expression '(' argumentList ')'
     | namedType '(' argumentList ')'
     | '(' typeRef ')' expression


### PR DESCRIPTION
The return type of extern functions can be a specialized type
receiving a type variable (hence a nonTypeName) as a type argument.
For example:
`extern widget<T> createWidget<T, U>(U a, T b);`
(Example taken from `factory2.p4` in `p4-c/testdata/p4_16_samples/`)

For this reason, the non-terminal `typeArg` needs to have
`nonTypeName` as one of its variants.

But this introduces a conflict:
when the parser sees
`nonTypeName '<' nonTypeName`
it can't know if it is a `expression '<' expression` of a comparison
or a `expression '<' typeArg ...` of the begining of a function call.

This is why the non-terminal realTypeArg (corresponding to the old typeArg)
was introduced: to avoid that conflict.

This modification to the grammar corresponds to what is already implemented
by the compiler.