### PR TITLE
Allow table property names to be type names

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5431,9 +5431,17 @@ tableProperty
     : KEY '=' '{' keyElementList '}'
     | ACTIONS '=' '{' actionList '}'
     | CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
-    | optAnnotations CONST IDENTIFIER '=' initializer ';'
-    | optAnnotations IDENTIFIER '=' initializer ';'
+    | optAnnotations CONST nonTableKwName '=' initializer ';'
+    | optAnnotations nonTableKwName '=' initializer ';'
     ;
+
+nonTableKwName
+   : IDENTIFIER
+   | TYPE_IDENTIFIER
+   | APPLY
+   | STATE
+   | TYPE
+   ;
 ~ End P4Grammar
 
 The standard table properties include:

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -33,6 +33,14 @@ name
     | TYPE_IDENTIFIER
     ;
 
+nonTableKwName
+   : IDENTIFIER
+   | TYPE_IDENTIFIER
+   | APPLY
+   | STATE
+   | TYPE
+   ;
+
 optAnnotations
     : /* empty */
     | annotations
@@ -488,8 +496,8 @@ tableProperty
     : KEY '=' '{' keyElementList '}'
     | ACTIONS '=' '{' actionList '}'
     | CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
-    | optAnnotations CONST IDENTIFIER '=' initializer ';'
-    | optAnnotations IDENTIFIER '=' initializer ';'
+    | optAnnotations CONST nonTableKwName '=' initializer ';'
+    | optAnnotations nonTableKwName '=' initializer ';'
     ;
 
 keyElementList


### PR DESCRIPTION
This pr reflects into the grammar & spec
the changes made by pr1363 to p4c .