### PR TITLE
Draft proposal for structure overlays

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2553,9 +2553,8 @@ overlay IPv4 expand(IPv4_aligned s) {
 }
 ~ End P4Example
 
-An overlay must define all fields of the destination structure.  The
-"function" computing an overlay can only be used as an initializer in
-the declaration of a variable of the suitable type.  In an overlay
+The "function" computing an overlay can only be used as an initializer
+in the declaration of a variable of the suitable type.  In an overlay
 each bit from a source field must be used at most once.  This
 restriction is necessary to compute how the fields of the source
 structure are changed when the destination structure is updated.

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2541,8 +2541,11 @@ a `header_union` as an argument to an overlay..  A struct produced by
 an overlay can only contain fields of the base types: `bit<>` and
 `int<>`.  The only statement allowed within an overlay function is an
 assignment statement that assigns to a field of the destination.  The
-only expressions allowed within an overlay are field access, bit
-slicing and concatenation.
+only expressions allowed within an overlay are:
+- field access
+- bit slicing
+- concatenation
+- casts that convert in either direction between bit<W> and int<W> (but not casts that change the width)
 
 Under some restrictions overlays can be left-values:
 - they must be obtained by applying an overlay function to a left-value;
@@ -2555,30 +2558,67 @@ an overlay which is a left value will update the original structure or
 header.  If the input of an overlay is a header the rules about
 accessing uninitialized header fields are valid for the source header.
 
+The following example shows an use of overlays
+
 ~ Begin P4Example
-struct Addresses {
-    bit<32> source;
-    bit<32> destination;
+// In this header all fields are byte-aligned
+header IPv4_aligned {
+    bit<8>       version_ihl;
+    bit<8>       diffserv;
+    bit<16>      totalLen;
+    bit<16>      identification;
+    bit<16>      flags_fragOffset;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<16>      hdrChecksum;
+    bit<32>      srcAddr;
+    bit<32>      dstAddr;
 }
 
-struct Bytes {
-    bit<8> q0;
-    bit<8> q1;
-    bit<8> q2;
-    bit<8> q3;
+// Overlay of IPv4_aligned that exposes all fields
+struct IPv4 {
+    bit<4>       version;
+    bit<4>       ihl;
+    bit<8>       diffserv;
+    bit<16>      totalLen;
+    bit<16>      identification;
+    bit<3>       flags;
+    bit<13>      fragOffset;
+    bit<8>       ttl;
+    bit<8>       protocol;
+    bit<16>      hdrChecksum;
+    bit<32>      srcAddr;
+    bit<32>      dstAddr;
 }
 
-overlay Bytes sourceQuads(Addresses add) {
-   q0 = add.source[31:24];
-   q1 = add.source[23:16];
-   q2 = add.source[15:8];
-   q3 = add.source[7:0];
+overlay IPv4 expand(IPv4_aligned s) {
+    version = s.version_ihl[7:4];
+    ihl = s.version_ihl[3:0];
+    diffserv = s.diffserv;
+    totalLen = s.totalLen;
+    identification = s.identification;
+    flags = s.flags_fragOffset[15:13];
+    fragOffset = s.flags_fragOffset[12:0];
+    ttl = s.ttl;
+    protocol = s.protocol;
+    hdrChecksum = s.hdrChecksum;
+    srcAddr = s.srcAddr;
+    dstAddr = s.dstAddr;
 }
 
-Addresses a = { 0x01234567, 0x89ABCDEF };
-Fields    q = sourceQuads(a);  // q is { 0x01, 0x23, 0x45, 0x67 };
-q.q0 = 0; // q is { 0x0, 0x23, 0x45, 0x67 }, a is { 0x00234567, 0x89ABCDEF }
+parser P(...) {
+   IPv4_aligned header;
+   IPv4 fields = expand(header);
+   ...
+   state ipv4 {
+      packet.extract(header);
+      verify(fields.version == 5, error.UnsupportedVersion);
+   }
+}
 ~ End P4Example
+
+It is expected that such coding style will make it easier to generate
+efficient implementations on some architectures..
 
 ~ Begin P4Grammar
 overlayDeclaration

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2577,7 +2577,7 @@ overlay Bytes sourceQuads(Addresses add) {
 
 Addresses a = { 0x01234567, 0x89ABCDEF };
 Fields    q = sourceQuads(a);  // q is { 0x01, 0x23, 0x45, 0x67 };
-q.q0 = 0; // q is { 0x0, 0x23, 0x45, 0x67 }, a is { 0x00234556, 0x89ABCDEF }
+q.q0 = 0; // q is { 0x0, 0x23, 0x45, 0x67 }, a is { 0x00234567, 0x89ABCDEF }
 ~ End P4Example
 
 ~ Begin P4Grammar

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -7954,14 +7954,18 @@ The P4 compiler should provide:
 * Allow 1-bit signed values
 * Define the type of bit slices from signed and unsigned values to be unsigned.
 * Constrain `default` label position for `switch` statements.
-* Allow empty tuples.
-* Added `@deprecated` annotation.
-* Relaxed the structure of annotation bodies.
-* Removed the `@pkginfo` annotation, which is now defined by the P4Runtime specification.
-* Added `int` type (Section [#sec-infinite-precision-integers]).
-* Added error `ParserInvalidArgument` (Sections [#sec-packet-extract-two], [#sec-skip-bits]).
-* Clarified the significance of order of entries in `const entries` (Section [#sec-entries]).
+* Allow empty tuples (Seciton [#sec-tuple-types]).
+* Added `@deprecated` annotation (Section [#sec-deprecated-anno]).
+* Relaxed the structure of annotation bodies (Section [#sec-annotations]).
+* Removed the `@pkginfo` annotation. This is defined by the P4Runtime
+  specification.
+* Added `int` type (Section [#sec-infinite-precision-integers].)
+* Added error `ParserInvalidArgument` (Sections
+  [#sec-packet-extract-two], [#sec-skip-bits]).
+* Clarify the significance of order of entries in `const entries`
+  (Section [#sec-entries]).
 * Added methods to calculate header size (Section [#sec-ops-on-hdrs]).
+* Added structure overlays (Section [#sec-overlays]).
 
 ## Summary of changes made in version 1.1.0
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2517,11 +2517,11 @@ struct Fields {
 }
 
 overlay Fields sourceQuads(Addresses add) {
-   q0 = source.source[31:24];
-   q1 = source.source[23:16];
-   q2 = source.source[15:8];
-   q3 = source.source[7:0];
-   all = source.source ++ source.destination;
+   q0 = add.source[31:24];
+   q1 = add.source[23:16];
+   q2 = add.source[15:8];
+   q3 = add.source[7:0];
+   all = add.source ++ add.destination;
 }
 
 Addresses a = { 0x01234567, 0x89ABCDEF };

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2617,6 +2617,7 @@ parser P(...) {
 }
 ~ End P4Example
 
+In this example the `expand` overlay produces a left-value.
 It is expected that such coding style will make it easier to generate
 efficient implementations on some architectures..
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2530,7 +2530,8 @@ q.q0 = 0;   // q is { 0x00, 0x23, 0x45, 0x67, 0x0023456789ABCDEF }, a is { 0x002
 q.q1 = a.destination[7:0]; // q is { 0x00, 0xEF, 0x45, 0x67, 0x00EF456789ABCDEF }, a is { 0x00EF4567, 0x89ABCDEF }
 ~ End P4Example
 
-Applying an overlay to a left-value produces a left-value.
+Applying an overlay to a left-value produces a left-value.  An overlay
+must define all fields of the destination structure.
 
 Overlays can only be applied to `struct` and `header` objects, and
 they can only produce `struct` objects.  A struct produced by an

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1368,6 +1368,7 @@ declaration
     | errorDeclaration
     | matchKindDeclaration
     | functionDeclaration
+    | overlayDeclaration
     ;
 ~ End P4Grammar
 
@@ -2531,15 +2532,17 @@ a.source[7:0] = a.destination[7:0]; // q is { 0x00, 0x00, 0x00, 0xEF, 0x000000EF
 ~ End P4Example
 
 An overlay must define all fields of the destination structure.
+The "function" computing an overlay can only be used as an initializer
+in the declaration of a variable of the suitable type.
 
 Overlays can only be applied to `struct` and `header` objects, and
-they can only produce `struct` objects.  A struct produced by an
-overlay can only contain fields of the base types: `bit<>` and
+they can only produce `struct` objects, but one cannot use a member of
+a `header_union` as an argument to an overlay..  A struct produced by
+an overlay can only contain fields of the base types: `bit<>` and
 `int<>`.  The only statement allowed within an overlay function is an
 assignment statement that assigns to a field of the destination.  The
 only expressions allowed within an overlay are field access, bit
-slicing and concatenation.  Referring to `header_union` fields within
-an overlay is not allowed.
+slicing and concatenation.
 
 Under some restrictions overlays can be left-values:
 - they must be obtained by applying an overlay function to a left-value;
@@ -2548,9 +2551,9 @@ Under some restrictions overlays can be left-values:
 The second restriction is necessary to compute how the fields of the
 source structure are changed when the destination structure is
 updated.  In the previous example `q` is not a left value.  Updating
-an overlay which is a left value will update the original structure.
-If the input of an overlay is a header the rules about accesing
-uninitialized header fields are valid for the source header.
+an overlay which is a left value will update the original structure or
+header.  If the input of an overlay is a header the rules about
+accessing uninitialized header fields are valid for the source header.
 
 ~ Begin P4Example
 struct Addresses {
@@ -2577,39 +2580,11 @@ Fields    q = sourceQuads(a);  // q is { 0x01, 0x23, 0x45, 0x67 };
 q.q0 = 0; // q is { 0x0, 0x23, 0x45, 0x67 }, a is { 0x00234556, 0x89ABCDEF }
 ~ End P4Example
 
-Overlays can be "stacked", as in the following example, where both `s`
-and `b` are left-values.
-
-~ Begin P4Example
-struct Int {
-   bit<32> i;
-}
-
-struct Short {
-   bit<16> s;
-}
-
-overlay Short FirstShort(Int i) {
-   s = i[31:16];
-}
-
-struct Byte {
-   bit<8> b;
-}
-
-overlay Byte FirstByte(Short s) {
-   b = s[15:8];
-}
-
-Int i = { 0x012345678 };
-Short s = FirstShort(i);
-Byte b = FirstByte(s);
-~ End P4Example
-
-The "function" computing an overlay can only be used as an initializer
-in the declaration of a variable of the suitable type.
-
-TODO: add P4 grammar.
+~ Begin P4Grammar
+overlayDeclaration
+    : OVERLAY functionDeclaration
+    ;
+~ End P4Grammar
 
 ### Tuple types { #sec-tuple-types }
 
@@ -8012,6 +7987,11 @@ are treated as keywords only in specific contexts (e.g., the keyword `actions`).
 | `switch` | `table`   | `transition` |  `true` |
 | `tuple` | `typedef` | `varbit`  | `verify` |
 | `void`       | ||
+| `overlay` | `package` | `parser` | `out`         |
+|  `return`  | `select` | `state` | `struct`   |
+| `switch` | `table`   | `transition` |  `true` |
+|  `tuple` | `typedef` | `varbit`  | `verify` |
+| `void`   |  |      |      |
 |------|------|------|------|
 
 # Appendix: P4 reserved annotations { #sec-p4-reserved-annotations }

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2483,6 +2483,64 @@ struct Parsed_headers {
 }
 ~ End P4Example
 
+### Structure overlays { #sec-overlays }
+
+An overlay allows the access to fields or subfields of a `struct` or
+`header` using alternative names.  An overlay is constructed by a
+special `overlay` function, that establishes a connection between the
+fields of the source and destination structure.
+
+In the following example we have two structure types: `Addresses` and
+`Fields`.  The overlay named `sourceQuads` is given a structure of
+type `Addresses` and allows accesses to its fields through a structure
+of type `Fields`.  The first four fields of `Fields` are individual
+bytes of `Addresses.source`, and the field `Fields.all` is the
+concatenation of `Source.source` and `Source.destination`.
+
+A variable of type `Addresses` named `a` is instantiated, and an
+overlay named `q` is created using the `sourceQuads` overlay.  Now
+fields of the `a` structure can be accessed read-write using fields of
+the `q` structure.
+
+~ Begin P4Example
+struct Addresses {
+    bit<32> source;
+    bit<32> destination;
+}
+
+struct Fields {
+    bit<8> q0;
+    bit<8> q1;
+    bit<8> q2;
+    bit<8> q3;
+    bit<64> all;
+}
+
+overlay Fields sourceQuads(Addresses add) {
+   q0 = source.source[31:24];
+   q1 = source.source[23:16];
+   q2 = source.source[15:8];
+   q3 = source.source[7:0];
+   all = source.source ++ source.destination;
+}
+
+Addresses a = { 0x01234567, 0x89ABCDEF };
+Fields    q = sourceQuads(a);  // q is { 0x01, 0x23, 0x45, 0x67, 0x0123456789ABCDEF };
+q.q0 = 0;   // q is { 0x00, 0x23, 0x45, 0x67, 0x0023456789ABCDEF }, a is { 0x00234567, 0x89ABCDEF }
+q.q1 = a.destination[7:0]; // q is { 0x00, 0xEF, 0x45, 0x67, 0x00EF456789ABCDEF }, a is { 0x00EF4567, 0x89ABCDEF }
+~ End P4Example
+
+Applying an overlay to a left-value produces a left-value.
+
+Overlays can only be applied to `struct` and `header` objects, and
+they can only produce `struct` objects.  A struct produced by an
+overlay can only contain fields of the base types: `bit`, `int`, and
+`bool`.  The only expressions allowed within an overlay are field
+access, bit slicing and concatenation.  Referring to `header_union`
+fields within an overlay is not allowed.
+
+TODO: add P4 grammar.
+
 ### Tuple types { #sec-tuple-types }
 
 A tuple is similar to a `struct`, in that it holds multiple

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2487,8 +2487,8 @@ struct Parsed_headers {
 
 An overlay allows the access to fields or subfields of a `struct` or
 `header` using alternative names.  An overlay is constructed by a
-special `overlay` function, that establishes a connection between the
-fields of the source and destination structure.
+special `overlay` "function", that establishes a connection between
+the fields of the source and destination structure.
 
 In the following example we have two structure types: `Addresses` and
 `Fields`.  The overlay named `sourceQuads` is given a structure of
@@ -2526,8 +2526,8 @@ overlay Fields sourceQuads(Addresses add) {
 
 Addresses a = { 0x01234567, 0x89ABCDEF };
 Fields    q = sourceQuads(a);  // q is { 0x01, 0x23, 0x45, 0x67, 0x0123456789ABCDEF };
-q.q0 = 0;   // q is { 0x00, 0x23, 0x45, 0x67, 0x0023456789ABCDEF }, a is { 0x00234567, 0x89ABCDEF }
-q.q1 = a.destination[7:0]; // q is { 0x00, 0xEF, 0x45, 0x67, 0x00EF456789ABCDEF }, a is { 0x00EF4567, 0x89ABCDEF }
+a.source = 0;   // q is { 0x00, 0x00, 0x00, 0x00, 0x0000000089ABCDEF }, a is { 0x0, 0x89ABCDEF }
+a.source[7:0] = a.destination[7:0]; // q is { 0x00, 0x00, 0x00, 0xEF, 0x000000EF89ABCDEF }, a is { 0x000000EF, 0x89ABCDEF }
 ~ End P4Example
 
 An overlay must define all fields of the destination structure.
@@ -2535,9 +2535,11 @@ An overlay must define all fields of the destination structure.
 Overlays can only be applied to `struct` and `header` objects, and
 they can only produce `struct` objects.  A struct produced by an
 overlay can only contain fields of the base types: `bit<>` and
-`int<>`.  The only expressions allowed within an overlay are field
-access, bit slicing and concatenation.  Referring to `header_union`
-fields within an overlay is not allowed.
+`int<>`.  The only statement allowed within an overlay function is an
+assignment statement that assigns to a field of the destination.  The
+only expressions allowed within an overlay are field access, bit
+slicing and concatenation.  Referring to `header_union` fields within
+an overlay is not allowed.
 
 Under some restrictions overlays can be left-values:
 - they must be obtained by applying an overlay function to a left-value;
@@ -2545,20 +2547,67 @@ Under some restrictions overlays can be left-values:
 
 The second restriction is necessary to compute how the fields of the
 source structure are changed when the destination structure is
-updated.  In the following example:
+updated.  In the previous example `q` is not a left value.  Updating
+an overlay which is a left value will update the original structure.
+If the input of an overlay is a header the rules about accesing
+uninitialized header fields are valid for the source header.
 
 ~ Begin P4Example
-struct Bits {
-   bit<2> b;
+struct Addresses {
+    bit<32> source;
+    bit<32> destination;
 }
 
-overlay Bits nonLeft(Addresses add) {
-   b = add.source[31] ++ add.source[31];
+struct Bytes {
+    bit<8> q0;
+    bit<8> q1;
+    bit<8> q2;
+    bit<8> q3;
 }
+
+overlay Bytes sourceQuads(Addresses add) {
+   q0 = add.source[31:24];
+   q1 = add.source[23:16];
+   q2 = add.source[15:8];
+   q3 = add.source[7:0];
+}
+
+Addresses a = { 0x01234567, 0x89ABCDEF };
+Fields    q = sourceQuads(a);  // q is { 0x01, 0x23, 0x45, 0x67 };
+q.q0 = 0; // q is { 0x0, 0x23, 0x45, 0x67 }, a is { 0x00234556, 0x89ABCDEF }
 ~ End P4Example
 
-an overaly built by applying `nonLeft` is never a left-value.  This is
-because the bit `add.source[31]` is used twice in defining `b`.
+Overlays can be "stacked", as in the following example, where both `s`
+and `b` are left-values.
+
+~ Begin P4Example
+struct Int {
+   bit<32> i;
+}
+
+struct Short {
+   bit<16> s;
+}
+
+overlay Short FirstShort(Int i) {
+   s = i[31:16];
+}
+
+struct Byte {
+   bit<8> b;
+}
+
+overlay Byte FirstByte(Short s) {
+   b = s[15:8];
+}
+
+Int i = { 0x012345678 };
+Short s = FirstShort(i);
+Byte b = FirstByte(s);
+~ End P4Example
+
+The "function" computing an overlay can only be used as an initializer
+in the declaration of a variable of the suitable type.
 
 TODO: add P4 grammar.
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2530,15 +2530,35 @@ q.q0 = 0;   // q is { 0x00, 0x23, 0x45, 0x67, 0x0023456789ABCDEF }, a is { 0x002
 q.q1 = a.destination[7:0]; // q is { 0x00, 0xEF, 0x45, 0x67, 0x00EF456789ABCDEF }, a is { 0x00EF4567, 0x89ABCDEF }
 ~ End P4Example
 
-Applying an overlay to a left-value produces a left-value.  An overlay
-must define all fields of the destination structure.
+An overlay must define all fields of the destination structure.
 
 Overlays can only be applied to `struct` and `header` objects, and
 they can only produce `struct` objects.  A struct produced by an
-overlay can only contain fields of the base types: `bit`, `int`, and
-`bool`.  The only expressions allowed within an overlay are field
+overlay can only contain fields of the base types: `bit<>` and
+`int<>`.  The only expressions allowed within an overlay are field
 access, bit slicing and concatenation.  Referring to `header_union`
 fields within an overlay is not allowed.
+
+Under some restrictions overlays can be left-values:
+- they must be obtained by applying an overlay function to a left-value;
+- each bit from a source field must be used at most once.
+
+The second restriction is necessary to compute how the fields of the
+source structure are changed when the destination structure is
+updated.  In the following example:
+
+~ Begin P4Example
+struct Bits {
+   bit<2> b;
+}
+
+overlay Bits nonLeft(Addresses add) {
+   b = add.source[31] ++ add.source[31];
+}
+~ End P4Example
+
+an overaly built by applying `nonLeft` is never a left-value.  This is
+because the bit `add.source[31]` is used twice in defining `b`.
 
 TODO: add P4 grammar.
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2491,74 +2491,7 @@ An overlay allows the access to fields or subfields of a `struct` or
 special `overlay` "function", that establishes a connection between
 the fields of the source and destination structure.
 
-In the following example we have two structure types: `Addresses` and
-`Fields`.  The overlay named `sourceQuads` is given a structure of
-type `Addresses` and allows accesses to its fields through a structure
-of type `Fields`.  The first four fields of `Fields` are individual
-bytes of `Addresses.source`, and the field `Fields.all` is the
-concatenation of `Source.source` and `Source.destination`.
-
-A variable of type `Addresses` named `a` is instantiated, and an
-overlay named `q` is created using the `sourceQuads` overlay.  Now
-fields of the `a` structure can be accessed read-write using fields of
-the `q` structure.
-
-~ Begin P4Example
-struct Addresses {
-    bit<32> source;
-    bit<32> destination;
-}
-
-struct Fields {
-    bit<8> q0;
-    bit<8> q1;
-    bit<8> q2;
-    bit<8> q3;
-    bit<64> all;
-}
-
-overlay Fields sourceQuads(Addresses add) {
-   q0 = add.source[31:24];
-   q1 = add.source[23:16];
-   q2 = add.source[15:8];
-   q3 = add.source[7:0];
-   all = add.source ++ add.destination;
-}
-
-Addresses a = { 0x01234567, 0x89ABCDEF };
-Fields    q = sourceQuads(a);  // q is { 0x01, 0x23, 0x45, 0x67, 0x0123456789ABCDEF };
-a.source = 0;   // q is { 0x00, 0x00, 0x00, 0x00, 0x0000000089ABCDEF }, a is { 0x0, 0x89ABCDEF }
-a.source[7:0] = a.destination[7:0]; // q is { 0x00, 0x00, 0x00, 0xEF, 0x000000EF89ABCDEF }, a is { 0x000000EF, 0x89ABCDEF }
-~ End P4Example
-
-An overlay must define all fields of the destination structure.
-The "function" computing an overlay can only be used as an initializer
-in the declaration of a variable of the suitable type.
-
-Overlays can only be applied to `struct` and `header` objects, and
-they can only produce `struct` objects, but one cannot use a member of
-a `header_union` as an argument to an overlay..  A struct produced by
-an overlay can only contain fields of the base types: `bit<>` and
-`int<>`.  The only statement allowed within an overlay function is an
-assignment statement that assigns to a field of the destination.  The
-only expressions allowed within an overlay are:
-- field access
-- bit slicing
-- concatenation
-- casts that convert in either direction between bit<W> and int<W> (but not casts that change the width)
-
-Under some restrictions overlays can be left-values:
-- they must be obtained by applying an overlay function to a left-value;
-- each bit from a source field must be used at most once.
-
-The second restriction is necessary to compute how the fields of the
-source structure are changed when the destination structure is
-updated.  In the previous example `q` is not a left value.  Updating
-an overlay which is a left value will update the original structure or
-header.  If the input of an overlay is a header the rules about
-accessing uninitialized header fields are valid for the source header.
-
-The following example shows an use of overlays
+The following example shows an use of overlays:
 
 ~ Begin P4Example
 // In this header all fields are byte-aligned
@@ -2575,35 +2508,20 @@ header IPv4_aligned {
     bit<32>      dstAddr;
 }
 
-// Overlay of IPv4_aligned that exposes all fields
-struct IPv4 {
-    bit<4>       version;
-    bit<4>       ihl;
-    bit<8>       diffserv;
-    bit<16>      totalLen;
-    bit<16>      identification;
-    bit<3>       flags;
-    bit<13>      fragOffset;
-    bit<8>       ttl;
-    bit<8>       protocol;
-    bit<16>      hdrChecksum;
-    bit<32>      srcAddr;
-    bit<32>      dstAddr;
-}
-
+// This overlay introduces a structure type named IPv4
 overlay IPv4 expand(IPv4_aligned s) {
-    version = s.version_ihl[7:4];
-    ihl = s.version_ihl[3:0];
-    diffserv = s.diffserv;
-    totalLen = s.totalLen;
-    identification = s.identification;
-    flags = s.flags_fragOffset[15:13];
-    fragOffset = s.flags_fragOffset[12:0];
-    ttl = s.ttl;
-    protocol = s.protocol;
-    hdrChecksum = s.hdrChecksum;
-    srcAddr = s.srcAddr;
-    dstAddr = s.dstAddr;
+    bit<4>  version = s.version_ihl[7:4];
+    bit<4>  ihl = s.version_ihl[3:0];
+    bit<8>  diffserv = s.diffserv;
+    bit<16> totalLen = s.totalLen;
+    bit<16> identification = s.identification;
+    bit<3>  flags = s.flags_fragOffset[15:13];
+    bit<13> fragOffset = s.flags_fragOffset[12:0];
+    bit<8>  ttl = s.ttl;
+    bit<8>  protocol = s.protocol;
+    bit<16> hdrChecksum = s.hdrChecksum;
+    bit<32> srcAddr = s.srcAddr;
+    bit<32> dstAddr = s.dstAddr;
 }
 
 parser P(...) {
@@ -2617,15 +2535,72 @@ parser P(...) {
 }
 ~ End P4Example
 
-In this example the `expand` overlay produces a left-value.
 It is expected that such coding style will make it easier to generate
-efficient implementations on some architectures..
+efficient implementations on some architectures.
+
+The `_ = _;` notation indicates that all fields of a source which have
+not yet been referenced are mapped unchanged to corresponding fields
+of the destination.  Using this notation, the previous overlay can be
+simplified as:
+
+~ Begin P4Example
+overlay IPv4 expand(IPv4_aligned s) {
+    bit<4>  version = s.version_ihl[7:4];
+    bit<4>  ihl = s.version_ihl[3:0];
+    bit<3>  flags = s.flags_fragOffset[15:13];
+    bit<13> fragOffset = s.flags_fragOffset[12:0];
+    _ = _; // map all remaining fields unchanged
+}
+~ End P4Example
+
+An overlay must define all fields of the destination structure.  The
+"function" computing an overlay can only be used as an initializer in
+the declaration of a variable of the suitable type.  In an overlay
+each bit from a source field must be used at most once.  This
+restriction is necessary to compute how the fields of the source
+structure are changed when the destination structure is updated.
+
+Overlays can only be applied to `struct` and `header` objects, and
+they can only produce `struct` objects.  One cannot use a member of
+a `header_union` as an argument to an overlay.  A struct produced by
+an overlay can only contain fields of the base types: `bit<>` and
+`int<>`.  The only statement allowed within an overlay function is an
+assignment statement that assigns to a field of the destination.  The
+only expressions allowed within an overlay are:
+- field access
+- bit slicing
+- concatenation
+- casts that convert in either direction between bit<W> and int<W> (but not casts that
+  change the width)
+
+An overlay applied to a left-value is also a left-value.  Updating an
+overlay which is a left value will update the original structure or
+header.  If the input of an overlay is a header the rules about
+accessing uninitialized header fields are valid for the source header.
 
 ~ Begin P4Grammar
 overlayDeclaration
     : OVERLAY functionDeclaration
     ;
 ~ End P4Grammar
+
+An overlay can be implemented by the compiler by maintaining a map
+between each source bit and the corresponding destination bit.  Using
+this information the compiler can rewrite operations on the overlay by
+replacing them with operations performed directly on the source data
+structure.  For the previous example, the compiler could rewrite the
+parser `P` as follows:
+
+~ Begin P4Example
+parser P(...) {
+   IPv4_aligned header;
+   ...
+   state ipv4 {
+      packet.extract(header);
+      verify(header.version_ihl[7:4] == 5, error.UnsupportedVersion);
+   }
+}
+~ End P4Example
 
 ### Tuple types { #sec-tuple-types }
 

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -16,6 +16,7 @@ declaration
     | errorDeclaration
     | matchKindDeclaration
     | functionDeclaration
+    | overlayDeclaration
     ;
 
 nonTypeName
@@ -561,6 +562,10 @@ initializer
     ;
 
 /************************* Expressions ****************************/
+
+overlayDeclaration
+    : OVERLAY functionDeclaration
+    ;
 
 functionDeclaration
     : functionPrototype blockStatement


### PR DESCRIPTION
This is an initial draft for a proposal for adding structure overlays to P4.

The design is more general than the other proposals we have heard. The main difference is that an overlay is a separate function-like object that can is applied to a structure instance to produce a different structure instance. This enables people to create overlays for structs that are defined in library files, without requiring them to modify the libraries. 

Please comment on this proposal.

I believe that overlays can be implemented easily just in the compiler front-end; the compiler will just rewrite all field accesses to overlays as field accesses to the underlying structure. So they are just some nice syntactic sugar.

They have a very clear semantics, and are a much cleaner way to implement much of the functionality that is provided by C-style unions. We have debated in the past whether to have C-style unions, but I believe they won't be necessary at all with this proposal.