### PR TITLE
Clarify sub-parser example in P4_16 spec

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5179,6 +5179,7 @@ parser caller(packet_in packet, out Headers h) {
      callee() subparser;  // instance of callee
      state subroutine {
           subparser.apply(packet, h.ipv4);  // invoke sub-parser
+          transition accept;  // accept if sub-parser ends in accept state
      }
 }
 ~ End P4Example


### PR DESCRIPTION
We add an "accept" transition after invoking the sub-parser. Without it
there is an implicit "reject" transition for all packets, no matter what
state the sub-parser ends in.

I believe the example makes more sense like this and is more
representative of what someone would actually write.