### PR TITLE
PSA - Change prohibition to "need not be supported"

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -2390,8 +2390,9 @@ in a form defined by the P4 Runtime API specification.
 
 A PSA program can instantiate multiple Digest instances in the same
 IngressDeparser control block, and make at most one `pack` call on
-each instance during a single execution of this control block. Digest 
-cannot be used in the EgressDeparser control block.
+each instance during a single execution of this control block.
+A PSA implementation need not support the use of the Digest
+extern in the EgressDeparser control block.
 
 There is no requirement that if multiple Digest messages are created
 while processing the same packet, that these messages must be "bundled


### PR DESCRIPTION
In general, if a feature is something we do not want to require PSA
implementations to support in some version of the PSA spec, it is
preferable to say "X need not be supported" rather than "you cannot do
X".  The former means a PSA implementation _may_ support it if they
want, and they should be able to.  Saying "you cannot do X" makes it
sound like an implementation will violate the PSA spec if it supports
features that are not required.