### PR TITLE
Update P4-16-spec.mdk

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2012,7 +2012,7 @@ types. For additional examples of literals see Section
 |----------|--------------------|
 | `10`    | Type is `int`, value is 10 |
 | `8w10`  | Type is `bit<8>`, value is 10 |
-| `8s10`  | Type is `int<10>`, value is 10 |
+| `8s10`  | Type is `int<8>`, value is 10 |
 | `2s3`   | Type is `int<2>`, value is -1 (last 2 bits), overflow warning |
 | `1w10`  | Type is `bit<1>`, value is 0 (last bit), overflow warning |
 | `1s10`  | Error: 1-bit signed type is illegal |


### PR DESCRIPTION
fixing a simple typo in section "Integer literal types"