### PR TITLE
PSA - Remove obsolete extern definition of ValueSet from psa.p4 inclu…

### DIFF
--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -29,6 +29,7 @@ check:
 	${P4C} examples/psa-example-counters.p4
 	${P4C} examples/psa-example-digest.p4
 	${P4C} examples/psa-example-incremental-checksum.p4
+	${P4C} examples/psa-example-incremental-checksum2.p4
 	${P4C} examples/psa-example-parser-checksum.p4
 	${P4C} examples/psa-example-parser-error-handling.p4
 	${P4C} examples/psa-example-recirculate.p4
@@ -40,23 +41,10 @@ check:
 # psa-example-mirror-on-drop.p4 needs updates for latest psa.p4
 #	${P4C} examples/psa-example-mirror-on-drop.p4
 
-# psa-example-incremental-checksum2.p4 fails with latest p4test as of
-# 2017-Dec-04 because of call to InternetChecksum method set_state(),
-# because its argument is not a compile-time constant.  I am not sure
-# why that should be a problem.
-#	${P4C} examples/psa-example-incremental-checksum2.p4
-
 # psa-example-register1.p4 is almost identical to
 # psa-example-register2.p4, except that it attempts to return a struct
 # from a register read, and write a struct back to the register.  As
-# of 2017-Dec-04, the latest version of p4test gives an error if you
-# attempt this.
+# of 2018-Oct-19, the latest version of p4test gives an error if you
+# attempt this, I believe somewhere in one of the mid end passes.  It
+# is definitely not in the bmv2 back end code.
 #	${P4C} examples/psa-example-register1.p4
-
-# These have been moved to the examples/historical directory for now,
-# and may be removed, given that it seems likely that parser value
-# sets will be created as a P4_16 language built-in construct, like
-# tables, rather than as a PSA-specific feature.
-#	${P4C} examples/psa-example-value-sets.p4
-#	${P4C} examples/psa-example-value-sets2.p4
-#	${P4C} examples/psa-example-value-sets3.p4

--- a/p4-16/psa/examples/historical/README.txt
+++ b/p4-16/psa/examples/historical/README.txt
@@ -1,0 +1,10 @@
+Files with 'value-sets' in their name:
+
+Parser value sets were originally considered to be defined as an
+extern object in PSA, but all of the ways discussed were felt to be
+too unwieldy, either for the P4 developer, the P4 compiler developers,
+or both, vs. making parser value sets a new P4_16 language construct
+defined in the language specification, similar to (but simpler than)
+tables.  That happened in early 2018.  All files with 'value-sets' as
+part of their name represent approaches considered for making them an
+extern in PSA.

--- a/p4-16/psa/examples/psa-example-register1.p4
+++ b/p4-16/psa/examples/psa-example-register1.p4
@@ -57,7 +57,7 @@ struct headers {
 }
 
 // BEGIN:Register_Example1_Part1
-const PortId_t NUM_PORTS = 512;
+const bit<32> NUM_PORTS = 512;
 
 typedef bit<48> ByteCounter_t;
 typedef bit<32> PacketCounter_t;
@@ -104,11 +104,11 @@ control ingress(inout headers hdr,
                 in    psa_ingress_input_metadata_t  istd,
                 inout psa_ingress_output_metadata_t ostd)
 {
-    Register<PacketByteCountState_t, PortId_t>((bit<32>) NUM_PORTS)
+    Register<PacketByteCountState_t, PortId_t>(NUM_PORTS)
         port_pkt_ip_bytes_in;
 
     apply {
-        ostd.egress_port = 0;
+        ostd.egress_port = (PortId_t) 0;
         if (hdr.ipv4.isValid()) {
             @atomic {
                 PacketByteCountState_t tmp;

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -739,27 +739,6 @@ extern Digest<T> {
 }
 // END:Digest_extern
 
-// BEGIN:ValueSet_extern
-extern ValueSet<D> {
-    ValueSet(int<32> size);
-    bool is_member(in D data);
-
-    /*
-    @ControlPlaneAPI
-    message ValueSetEntry {
-        uint32 value_set_id = 1;
-        // FieldMatch allows specification of exact, lpm, ternary, and
-        // range matching on fields for tables, and these options are
-        // permitted for the ValueSet extern as well.
-        repeated FieldMatch match = 2;
-    }
-
-    // ValueSetEntry should be added to the 'message Entity'
-    // definition, inside its 'oneof Entity' list of possibilities.
-    */
-}
-// END:ValueSet_extern
-
 // BEGIN:Programmable_blocks
 parser IngressParser<H, M, RESUBM, RECIRCM>(
     packet_in buffer,


### PR DESCRIPTION
…de file

The tentative definition of the ValueSet extern was left in the psa.p4
include file even after all descriptions of it were removed from
PSA.mdk.  Now that parser value sets have been added to the P4_16
language spec, we should remove all traces of the old extern
definition from PSA files.  This includes removing some value set
example programs from Makefile.

Other updates to the Makefile:

+ I tested and found that the latest version of p4test can compile the
  psa-example-incremental-checksum2.p4 program without errors, so
  added it to the list of programs compiled via 'make check'.

+ I tested the latest p4test with psa-example-register1.p4, after
  making changes to that program that were recently made to
  psa-example-register2.p4, and it still gives a similar error as it
  did a year ago due to limitation in p4c where extern methods cannot
  return structs.  Updated the date of the latest version of p4test
  that gives error in Makefile comments to today.