### PR TITLE
PSA add link to example PSA programs in specification

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -114,6 +114,13 @@ should follow several general guidelines:
 - Use as few resources as possible, e.g. table search key bits, array
   sizes, quantity of metadata associated with packets, etc.
 
+This document contains excerpts of several P4~16~ programs that use
+the `psa.p4` include file and demonstrate features of PSA.  Source
+code for the complete programs can be found in the official repository
+containing the PSA specification[^PSAExamplePrograms].
+
+[^PSAExamplePrograms]: <https://github.com/p4lang/p4-spec> in directory `p4-16/psa/examples`.  Direct link: <https://github.com/p4lang/p4-spec/tree/master/p4-16/psa/examples>
+
 
 # Naming conventions
 
@@ -407,7 +414,7 @@ casting a value of a wider type such as `PortIdInHeader_t` to the
 corresponding narrower type `PortId_t` truncates the excess most
 significant bits as part of the cast.
 
-Values of type `PortId_t` have a distinctive property in PSA
+Values of type `PortId_t` have an unusual property in PSA
 implementations.  Because it can make some hardware implementations
 more straightforward, the numerical values of fields with type
 `PortId_t` in the P4 data plane might not be a simple range of values
@@ -518,7 +525,7 @@ because the agent software will perform port translation for table
 keys.
 
 If this is not a reasonable thing to do, the example program
-psa-example-counters.p4 should be modified so that it does not do
+`psa-example-counters.p4` should be modified so that it does not do
 this, and scrub all other examples for any similar behavior.
 ~
 


### PR DESCRIPTION
Also change word "distinctive" to "unusual", since "distinctive" means
"characteristic of one person or thing", and it was being used to
refer to the numerical translation property of type PortId_t values,
which we expect will be used for multiple types, not only PortId_t.