### PR TITLE
Allow `int<1>`: fix for issue #668

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3318,7 +3318,7 @@ type. The result always has the same width as the left operand.
 - Extraction of a set of contiguous bits, also known as a slice, denoted by `[m:l]`,
   where `m` and `l` must be positive integers
   that are compile-time known values, and `m >= l`. The result is
-  a bit-string of width `m - l + 1`, including the bits numbered
+  a signed bit-string of width `m - l + 1`, including the bits numbered
   from `l` (which becomes the least significant bit of the result) to `m` (the
   most significant bit of the result) from the source operand. The conditions `0 <= l < W`
   and `l <= m < W` are checked statically (where `W` is
@@ -3328,7 +3328,7 @@ type. The result always has the same width as the left operand.
   at compile time. Slices are also l-values, which means that P4 supports assigning to a slice: ` e[m:l] = x `.
   The effect of this statement is to set bits `m` to `l` of `e` to the
   bit-pattern represented by `x`, and leaves all other bits of `e`
-  unchanged.  A slice of a signed integer is treated like a signed integer as well.
+  unchanged.  A slice of a signed integer is treated like an unsigned integer.
 
 ### A note about shifts
 
@@ -7125,6 +7125,8 @@ The P4 compiler should provide:
 
 ## Summary of changes made in version 1.2.0
 
+* Allow 1-bit signed values
+* Define the type of bit slices from signed and unsigned values to be unsigned.
 * Constrain `default` label position for `switch` statements.
 * Allow empty tuples.
 * Added `@deprecated` annotation.

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1953,7 +1953,7 @@ described in Section [#sec-bit-ops].
 
 Signed integers are represented using two's complement. An integer with `W`
 bits is declared as: `int<W>`. `W` must be an expression that evaluates to
-a compile-time known value that is a positive integer greater than 1.
+a compile-time known value that is a positive integer.
 
 Bits within an integer are numbered from `0` to `W-1`. Bit `0`
 is the least significant, and bit `W-1` is the sign bit.
@@ -1969,6 +1969,8 @@ bit values).
 
 All operations that can be performed on signed integers are described
 in Section [#sec-int-ops].
+
+A signed integer with width 1 can only have two legal values: 0 and -1.
 
 #### Dynamically-sized bit-strings
 
@@ -2035,7 +2037,7 @@ types. For additional examples of literals see Section
 | `8s10`  | Type is `int<8>`, value is 10 |
 | `2s3`   | Type is `int<2>`, value is -1 (last 2 bits), overflow warning |
 | `1w10`  | Type is `bit<1>`, value is 0 (last bit), overflow warning |
-| `1s10`  | Error: 1-bit signed type is illegal |
+| `1s10`  | Type is `int<1>`, value is -1, overflow warning |
 |----------|--------------------|
 
 ## Derived types { #sec-derived-types }
@@ -3247,7 +3249,7 @@ Bit-strings also support the following operations:
   at compile time. Slices are also l-values, which means that P4 supports assigning to a slice: ` e[m:l] = x `.
   The effect of this statement is to set bits `m` to `l` of `e` to the
   bit-pattern represented by `x`, and leaves all other bits of `e`
-  unchanged.
+  unchanged.  A slice of an unsigned integer is an unsigned integer.
 - Logical shift left and right with a runtime known unsigned integer
   value, denoted by `<<` and `>>` respectively. In a shift, the left operand is unsigned, and right operand must be either an
   expression of type `bit<S>` or a non-negative integer literal.
@@ -3313,6 +3315,20 @@ type. The result always has the same width as the left operand.
   - all result bits are zero when shifting left
   - all result bits are zero when shifting right a positive value
   - all result bits are one when shifting right a negative value
+- Extraction of a set of contiguous bits, also known as a slice, denoted by `[m:l]`,
+  where `m` and `l` must be positive integers
+  that are compile-time known values, and `m >= l`. The result is
+  a bit-string of width `m - l + 1`, including the bits numbered
+  from `l` (which becomes the least significant bit of the result) to `m` (the
+  most significant bit of the result) from the source operand. The conditions `0 <= l < W`
+  and `l <= m < W` are checked statically (where `W` is
+  the length of the source bit-string). Note that both endpoints of
+  the extraction are inclusive. The bounds are required to be
+  compile-time known values so that the result width can be computed
+  at compile time. Slices are also l-values, which means that P4 supports assigning to a slice: ` e[m:l] = x `.
+  The effect of this statement is to set bits `m` to `l` of `e` to the
+  bit-pattern represented by `x`, and leaves all other bits of `e`
+  unchanged.  A slice of a signed integer is treated like a signed integer as well.
 
 ### A note about shifts
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3318,7 +3318,7 @@ type. The result always has the same width as the left operand.
 - Extraction of a set of contiguous bits, also known as a slice, denoted by `[m:l]`,
   where `m` and `l` must be positive integers
   that are compile-time known values, and `m >= l`. The result is
-  a signed bit-string of width `m - l + 1`, including the bits numbered
+  an unsigned bit-string of width `m - l + 1`, including the bits numbered
   from `l` (which becomes the least significant bit of the result) to `m` (the
   most significant bit of the result) from the source operand. The conditions `0 <= l < W`
   and `l <= m < W` are checked statically (where `W` is

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2029,16 +2029,16 @@ The table below shows several examples of integer literals and their
 types. For additional examples of literals see Section
 [#sec-literals].
 
-+--------:+--------------------+
++--------:+----------------+
 | Literal | Interpretation |
-|----------|--------------------|
+|---------|----------------|
 | `10`    | Type is `int`, value is 10 |
 | `8w10`  | Type is `bit<8>`, value is 10 |
 | `8s10`  | Type is `int<8>`, value is 10 |
 | `2s3`   | Type is `int<2>`, value is -1 (last 2 bits), overflow warning |
 | `1w10`  | Type is `bit<1>`, value is 0 (last bit), overflow warning |
-| `1s10`  | Type is `int<1>`, value is -1, overflow warning |
-|----------|--------------------|
+| `1s1`   | Type is `int<1>`, value is -1, overflow warning |
+|---------|--------------------|
 
 ## Derived types { #sec-derived-types }
 


### PR DESCRIPTION
This allows the type `int<1>` and adds slices for signed values.
@jafingerhut : you have claimed this issue, but I wanted to discuss this next Monday so I took over.
