### PR TITLE
Constrain keys to be unique in key-value pair values for annotations

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6822,7 +6822,7 @@ keyValueList
 One useful variant of annotations is a comma-separated list of key-value (k-v)
 pairs. This can be used to assign multiple properties to an entity in a more concise and readable way.
 Multiple annotations of either form may be used and are cumulative, i.e. the list of k-v pairs will accumulate.
-If a given key appears more than once, then the latest value will replace all earlier ones.
+It is an error if a given key appears more than once for the same annotation name on the same P4 object.
 The following sections illustrate two ways of writing the same list of annotations.
 
 ### Multiple Annotation Statements Each using Single K-V Expression
@@ -7009,6 +7009,7 @@ The P4 compiler should provide:
 
 * Constrain `default` label position for `switch` statements
 * Allow empty tuples
+* Constrain keys to be unique in annotation values specified as key-value pairs
 
 ## Summary of changes made in version 1.1.0
 


### PR DESCRIPTION
This suggested change arose during discussion of this issue: https://github.com/p4lang/p4-spec/issues/715

but that issue is _not_ resolved by this PR, as it was originally about a different question not addressed here.