### PR TITLE
Add a table listing which types upon which you can do typedef and type

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2450,7 +2450,7 @@ The table below lists all types that may appear as base types in a
 | `bit<W>`         | allowed            | allowed         |
 | `int<W>`         | allowed            | allowed         |
 | `varbit<W>`      | allowed            | error           |
-| `int`            | error              | error           |
+| `int`            | allowed            | error           |
 | `void`           | error              | error           |
 | `error`          | allowed            | error           |
 | `match_kind`     | error              | error           |
@@ -2460,7 +2460,7 @@ The table below lists all types that may appear as base types in a
 | header stack     | allowed            | error           |
 | `header_union`   | allowed            | error           |
 | `struct`         | allowed            | error           |
-| `tuple`          | allowed            | allowed         |
+| `tuple`          | allowed            | error           |
 | a `typedef` name | allowed            | allowed[^type_allowed] |
 | a `type` name    | allowed            | allowed         |
 |------------------|--------------------|-----------------|

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2440,6 +2440,35 @@ Note the two-argument `extract` method (see Section
 [#sec-packet-extract-two]) on packets only supports a single `varbit`
 field in a header.
 
+The table below lists all types that may appear as base types in a
+`typedef` or `type` declaration.
+
+
+|------------------|--------------------------------------|
+| Base type B      | `typedef B <name>` | `type B <name>` |
++:-----------------+:-------------------+:----------------+
+| `bit<W>`         | allowed            | allowed         |
+| `int<W>`         | allowed            | allowed         |
+| `varbit<W>`      | allowed            | error           |
+| `int`            | error              | error           |
+| `void`           | error              | error           |
+| `error`          | allowed            | error           |
+| `match_kind`     | error              | error           |
+| `bool`           | allowed            | allowed         |
+| `enum`           | allowed            | error           |
+| `header`         | allowed            | error           |
+| header stack     | allowed            | error           |
+| `header_union`   | allowed            | error           |
+| `struct`         | allowed            | error           |
+| `tuple`          | allowed            | allowed         |
+| a `typedef` name | allowed            | allowed[^type_allowed] |
+| a `type` name    | allowed            | allowed         |
+|------------------|--------------------|-----------------|
+
+[^type_allowed]: `type B <name>` is allowed for a type name `B`
+    defined via `typedef X B` if `type X <name>` is allowed.
+
+
 ### Synthesized data types { #sec-synth-types }
 
 For the purposes of type-checking the P4 compiler can synthesize some


### PR DESCRIPTION
The contents of the table are based upon the current p4c
implementation, tested via the p4test command.