### PR TITLE
P4_16: Move text on reading uninit vals and writing to invalid headers

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3640,6 +3640,10 @@ if they have the same type and all of their fields can be recursively
 compared for equality.  Two structures are equal if and only if all
 their corresponding fields are equal.
 
+See Section [#sec-uninitialized-values-and-writing-invalid-headers]
+for a description of the behavior if `struct` fields are read without
+being initialized.
+
 ## Operations on headers { #sec-ops-on-hdrs }
 
 Headers provide the same operations as `struct`s. Assignment between
@@ -3653,52 +3657,6 @@ of the header.
 "true". It can only be applied to an l-value.
 - The method `setInvalid()` sets the header's validity bit to
 "false". It can only be applied to an l-value.
-
-The result of reading a field in any of the situations below is that
-some unspecified value will be used for that field.
-
-- reading a field from a header that is currently invalid.
-- reading a field from a header that is currently valid, but the field
-  has not been initialized since the header was last made valid.
-- reading any other value that has not been initialized, e.g. a field
-  from a `struct`.
-
-Where a header is mentioned, it may be a member of a `header_union`,
-an element in a header stack, or a normal header.  This unspecified
-value could differ from one such read to another.
-
-For a field with a type of `enum` or `error`, the unspecified value
-that is read might not be equal to any of the values defined for that
-type.  Such an unspecified value should still lead to predictable
-behavior in cases where any legal value would match, e.g. it should
-match in any of these situations:
-
-- If used in a `select` expression, it should match `default` or `_`
-  in a key set expression.
-- If used as a key with `match_kind` `ternary` in a table, it should
-  match a table entry where the field has all bit positions "don't
-  care".
-- If used as a key with `match_kind` `lpm` in a table, it should match
-  a table entry where the field has a prefix length of 0.
-
-Consider a situation where a `header_union` `u1` has member headers
-`u1.h1` and `u1.h2`, and at a given point in the program's execution
-`u1.h1` is valid and `u1.h2` is invalid.  If a write is attempted to a
-field of the invalid member header `u1.h2`, then any or all of the
-fields of the valid member header `u1.h1` may change as a result.
-Such a write must not change the validity of any member headers of
-`u1`, nor any other state that is currently defined in the system,
-whether it is defined state in header fields or anywhere else.
-
-If a write is performed to a field in a currently invalid header, and
-that header is not part of a `header_union`, that write must not
-change any state that is currently defined in the system, neither in
-header fields nor anywhere else.  In particular, that invalid header
-must remain invalid.
-
-Either of the kinds of writes to fields in a currently invalid header
-is allowed to modify state whose values are not defined, e.g. the
-values of fields in headers that are currently invalid.
 
 A header object can be initialized with a list expression, similar to
 a `struct`---the list fields are assigned to the header fields in the
@@ -3715,6 +3673,11 @@ Two headers can be compared for equality (==) or inequality (!=) only
 if they have the same type.  Two headers are equal if and only if they
 are both invalid, or they are both valid and all their corresponding
 fields are equal.
+
+See Section [#sec-uninitialized-values-and-writing-invalid-headers]
+for a description of the behavior if header fields are read without
+being initialized, or header fields are written to a currently invalid
+header.
 
 ## Operations on header stacks { #sec-expr-hs }
 
@@ -4174,6 +4137,64 @@ bool b0 = x == (U32)z; // cast needed
 bool b1 = (bit<32>)x == z;  // cast needed
 bool b2 = x == y;  // no cast needed
 ~ End P4Example
+
+## Reading uninitialized values and writing fields of invalid headers { #sec-uninitialized-values-and-writing-invalid-headers }
+
+The result of reading a value in any of the situations below is that
+some unspecified value will be used for that field.
+
+- reading a field from a header that is currently invalid.
+- reading a field from a header that is currently valid, but the field
+  has not been initialized since the header was last made valid.
+- reading any other value that has not been initialized, e.g. a field
+  from a `struct`, any uninitialized variable inside of an `action` or
+  `control`, or an `out` parameter of a `control` or `action` you have
+  called, which was not assigned a value during the execution of that
+  `control` or `action` (this list of examples is not intended to be
+  exhaustive).
+
+Where a header is mentioned, it may be a member of a `header_union`,
+an element in a header stack, or a normal header.  This unspecified
+value could differ from one such read to another.
+
+For an uninitialized field or variable with a type of `enum` or
+`error`, the unspecified value that is read might not be equal to any
+of the values defined for that type.  Such an unspecified value should
+still lead to predictable behavior in cases where any legal value
+would match, e.g. it should match in any of these situations:
+
+- If used in a `select` expression, it should match `default` or `_`
+  in a key set expression.
+- If used as a key with `match_kind` `ternary` in a table, it should
+  match a table entry where the field has all bit positions "don't
+  care".
+- If used as a key with `match_kind` `lpm` in a table, it should match
+  a table entry where the field has a prefix length of 0.
+
+Consider a situation where a `header_union` `u1` has member headers
+`u1.h1` and `u1.h2`, and at a given point in the program's execution
+`u1.h1` is valid and `u1.h2` is invalid.  If a write is attempted to a
+field of the invalid member header `u1.h2`, then any or all of the
+fields of the valid member header `u1.h1` may change as a result.
+Such a write must not change the validity of any member headers of
+`u1`, nor any other state that is currently defined in the system,
+whether it is defined state in header fields or anywhere else.
+
+If a write is performed to a field in a currently invalid header, and
+that header is not part of a `header_union`, that write must not
+change any state that is currently defined in the system, neither in
+header fields nor anywhere else.  In particular, that invalid header
+must remain invalid.
+
+Either of the kinds of writes to fields in a currently invalid header
+is allowed to modify state whose values are not defined, e.g. the
+values of fields in headers that are currently invalid.
+
+For a top level `parser` or `control` in an architecture, it is up to
+that architecture to specify whether `control` parameters with
+direction `in` or `inout` are initialized when the control is called,
+and under what conditions they are initialized, and if so, what their
+values will be.
 
 # Function declarations { #sec-functions }
 


### PR DESCRIPTION
I moved this text into its own section, and added cross-references to
it from where the text was moved from, Section 8.14 "Operations on
headers", and another in Section 8.13 "Operations on structs", even
though it really does apply to reading uninitialized of _any_ types.

Motivation for this movement: The moved text specifially describes the
behavior when an uninitialized value of type `enum` or `error` is
read, even though a header is not allowed to contain fields with those
types.  With the text in Section 8.14, one could be easily be confused
into believing that it implied that a header could contain fields of
those types.

The only changes I made to the moved text are as follows:

+ Changed the first sentence to "The result of reading a field" to
  "The result of reading a value", since reading uninitialized values
  applies not only to fields of headers and structs, but also to local
  variables with types like `bit<W>` or `bool`.

+ Added a few more explicit examples of situations where an
  uninitialized value can be read, changing this text: "reading any
  other value that has not been initialized, e.g. a field from a
  `struct`." to this: "reading any other value that has not been
  initialized, e.g. a field from a `struct`, any uninitialized
  variable inside of an `action` or `control`, or an `out` parameter
  of a `control` or `action` you have called, which was not assigned a
  value during the execution of that `control` or `action` (this list
  of examples is not intended to be exhaustive)."

+ Added this paragraph at the end of the new section:
  "For a top level `parser` or `control` in an architecture, it is up
  to that architecture to specify whether `control` parameters with
  direction `in` or `inout` are initialized when the control is
  called, and under what conditions they are initialized, and if so,
  what their values will be."