### PR TITLE
Clarify the significance of order multiple table entries in 'const en…

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5730,8 +5730,9 @@ Sec. [#sec-table-props]). The table key type must match the type of
 the element of the set. `actionRef` must be an action which
 appears in the table actions list, with all its arguments bound.
 
-Entries in a table are matched in the program order, stopping at the
-first matching entry.
+Entries in a table with at least one `ternary` search key field are matched in
+the program order, stopping at the first matching entry. Architectures should
+define the significance of entry order (if any) for other kinds of tables.
 
 Depending on the `match_kind` of the keys, key set expressions may define
 one or multiple entries. The compiler will synthesize the correct number of

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5730,9 +5730,11 @@ Sec. [#sec-table-props]). The table key type must match the type of
 the element of the set. `actionRef` must be an action which
 appears in the table actions list, with all its arguments bound.
 
-Entries in a table with at least one `ternary` search key field are matched in
-the program order, stopping at the first matching entry. Architectures should
-define the significance of entry order (if any) for other kinds of tables.
+If the runtime API requires a priority for the entries of a table --
+e.g. when using the P4 Runtime API, tables with at least one `ternary`
+search key field -- then the entries are matched in program order,
+stopping at the first matching entry. Architectures should define the
+significance of entry order (if any) for other kinds of tables.
 
 Depending on the `match_kind` of the keys, key set expressions may define
 one or multiple entries. The compiler will synthesize the correct number of

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5730,11 +5730,12 @@ Sec. [#sec-table-props]). The table key type must match the type of
 the element of the set. `actionRef` must be an action which
 appears in the table actions list, with all its arguments bound.
 
-If the runtime API requires a priority for the entries of a table --
-e.g. when using the P4 Runtime API, tables with at least one `ternary`
-search key field -- then the entries are matched in program order,
-stopping at the first matching entry. Architectures should define the
-significance of entry order (if any) for other kinds of tables.
+If the runtime API requires a priority for the entries of a
+table---e.g. when using the P4 Runtime API, tables with at least one
+`ternary` search key field---then the entries are matched in program
+order, stopping at the first matching entry. Architectures should
+define the significance of entry order (if any) for other kinds of
+tables.
 
 Depending on the `match_kind` of the keys, key set expressions may define
 one or multiple entries. The compiler will synthesize the correct number of


### PR DESCRIPTION
…tries'

With this PR: https://github.com/p4lang/p4-spec/pull/737 the PSA
architecture now defines the significant of the order of multiple
entries in tables with a 'const entries' table property for all kinds
of tables, in a way that is consistent with the changes proposed here.

I will soon create a similar PR for the v1model architecture for BMv2
simple_switch that makes the same kinds of statements for it.