### PR TITLE
Mention that an enum with an underlying type is also called serializable

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2134,9 +2134,9 @@ created type.  The underlying representation of the `Suits` enum is not
 specified, so their "size" in bits is not specified (it is
 target-specific).
 
-It is also possible to specify an `enum` with an underlying representation,
-also known as a serializable `enum`, because it can be included as a field
-in headers that are parsed and deparsed.
+It is also possible to specify an `enum` with an underlying representation.
+These are sometimes called serializable `enum`s, because fields of these
+types can be included as a field in headers that are parsed and deparsed.
 This requires the programmer provide both the fixed-width unsigned integer type and an associated
 fixed-width unsigned integer value for each symbolic entry in the enumeration.  For example, the
 declaration

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2134,7 +2134,9 @@ created type.  The underlying representation of the `Suits` enum is not
 specified, so their "size" in bits is not specified (it is
 target-specific).
 
-It is also possible to specify an `enum` with an underlying representation.
+It is also possible to specify an `enum` with an underlying representation,
+also known as a serializable `enum`, because it can be included as a field
+in headers that are parsed and deparsed.
 This requires the programmer provide both the fixed-width unsigned integer type and an associated
 fixed-width unsigned integer value for each symbolic entry in the enumeration.  For example, the
 declaration

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2135,8 +2135,8 @@ specified, so their "size" in bits is not specified (it is
 target-specific).
 
 It is also possible to specify an `enum` with an underlying representation.
-These are sometimes called serializable `enum`s, because fields of these
-types can be included as a field in headers that are parsed and deparsed.
+These are sometimes called serializable `enum`s, because fields of
+these types can be included in headers that are parsed and deparsed.
 This requires the programmer provide both the fixed-width unsigned integer type and an associated
 fixed-width unsigned integer value for each symbolic entry in the enumeration.  For example, the
 declaration

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2135,8 +2135,8 @@ specified, so their "size" in bits is not specified (it is
 target-specific).
 
 It is also possible to specify an `enum` with an underlying representation.
-These are sometimes called serializable `enum`s, because fields of
-these types can be included in headers that are parsed and deparsed.
+These are sometimes called serializable `enum`s, because headers are
+allowed to have fields with such `enum` types.
 This requires the programmer provide both the fixed-width unsigned integer type and an associated
 fixed-width unsigned integer value for each symbolic entry in the enumeration.  For example, the
 declaration


### PR DESCRIPTION
Before this change, the word "serializable" does not occur anywhere in
the language specification.  An enum value with an underlying type is
often called a serializable enum in conversation between P4
implementers, including in the p4c implementation, so having a way to
find it in the language spec by that name seems like a good idea.