### PR TITLE
Proposed new error value for implementations that restrict parser ali…

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2231,7 +2231,7 @@ size." Headers containing `varbit` fields have "variable
 size." The size (in bits) of a fixed-size header is a constant, and it
 is simply the sum of the sizes of all component fields (without
 counting the validity bit). There is no padding or alignment of the
-header fields. Architectures may impose additional constraints on
+header fields. Implementations may impose additional constraints on
 header types---e.g., restricting headers to sizes that are an integer
 number of bytes.
 
@@ -5021,6 +5021,8 @@ is captured by the following pseudo-code:
 ~ Begin P4Pseudo
 void packet_in.extract<T>(out T headerLvalue,
                           in bit<32> variableFieldSize) {
+   // implementations _may_ include the following line, but need not
+   verify(variableFieldSize[2:0] == 0, error.ParserInvalidAlignment);
    bitsToExtract = sizeOfFixedPart(headerLvalue) + variableFieldSize;
    lastBitNeeded = this.nextBitIndex + bitsToExtract;
    ParserModel.verify(this.lengthInBits >= lastBitNeeded, error.PacketTooShort);
@@ -5156,6 +5158,8 @@ given in pseudo-code as follows:
 
 ~ Begin P4Pseudo
 void packet_in.advance(bit<32> bits) {
+   // implementations _may_ include the following line, but need not
+   verify(bits[2:0] == 0, error.ParserInvalidAlignment);
    lastBitNeeded = this.nextBitIndex + bits;
    ParserModel.verify(this.lengthInBits >= lastBitNeeded, error.PacketTooShort);
    this.nextBitIndex += bits;
@@ -7090,7 +7094,9 @@ error {
     NoMatch,           /// 'select' expression has no matches.
     StackOutOfBounds,  /// Reference to invalid element of a header stack.
     HeaderTooShort,    /// Extracting too many bits into a varbit field.
-    ParserTimeout      /// Parser execution time limit exceeded.
+    ParserTimeout,     /// Parser execution time limit exceeded.
+    ParserInvalidAlignment  /// extract or advance would leave parser with
+                       /// alignment unsupported by the implementation.
 }
 extern packet_in {
     /// Read a header from the packet into a fixed-sized header @hdr

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2231,7 +2231,7 @@ size." Headers containing `varbit` fields have "variable
 size." The size (in bits) of a fixed-size header is a constant, and it
 is simply the sum of the sizes of all component fields (without
 counting the validity bit). There is no padding or alignment of the
-header fields. Implementations may impose additional constraints on
+header fields. Targets may impose additional constraints on
 header types---e.g., restricting headers to sizes that are an integer
 number of bytes.
 
@@ -5021,7 +5021,7 @@ is captured by the following pseudo-code:
 ~ Begin P4Pseudo
 void packet_in.extract<T>(out T headerLvalue,
                           in bit<32> variableFieldSize) {
-   // implementations are allowed to include the following line, but need not
+   // targets are allowed to include the following line, but need not
    // verify(variableFieldSize[2:0] == 0, error.ParserInvalidArgument);
    bitsToExtract = sizeOfFixedPart(headerLvalue) + variableFieldSize;
    lastBitNeeded = this.nextBitIndex + bitsToExtract;
@@ -5158,7 +5158,7 @@ given in pseudo-code as follows:
 
 ~ Begin P4Pseudo
 void packet_in.advance(bit<32> bits) {
-   // implementations are allowed to include the following line, but need not
+   // targets are allowed to include the following line, but need not
    // verify(bits[2:0] == 0, error.ParserInvalidArgument);
    lastBitNeeded = this.nextBitIndex + bits;
    ParserModel.verify(this.lengthInBits >= lastBitNeeded, error.PacketTooShort);
@@ -7003,6 +7003,8 @@ The P4 compiler should provide:
 |       |          | Clarified semantics of operations on invalid headers, added |
 |       |          | restrictions on arguments to calls, and modified precedence of |
 |       |          | bitwise operators. |
+|-----|-----|-----|
+| 1.2.0 | April TBD, 2019 | Added error `ParserInvalidArgument`. |
 |-----|-----|-----|
 
 ## Summary of changes made in version 1.2.0

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -7095,8 +7095,8 @@ error {
     StackOutOfBounds,  /// Reference to invalid element of a header stack.
     HeaderTooShort,    /// Extracting too many bits into a varbit field.
     ParserTimeout,     /// Parser execution time limit exceeded.
-    ParserInvalidArgument  /// parser operation was called with a value
-                       /// not supported by the implementation
+    ParserInvalidArgument  /// Parser operation was called with a value
+                           /// not supported by the implementation.
 }
 extern packet_in {
     /// Read a header from the packet into a fixed-sized header @hdr

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5021,8 +5021,8 @@ is captured by the following pseudo-code:
 ~ Begin P4Pseudo
 void packet_in.extract<T>(out T headerLvalue,
                           in bit<32> variableFieldSize) {
-   // implementations _may_ include the following line, but need not
-   verify(variableFieldSize[2:0] == 0, error.ParserInvalidAlignment);
+   // implementations are allowed to include the following line, but need not
+   // verify(variableFieldSize[2:0] == 0, error.ParserInvalidArgument);
    bitsToExtract = sizeOfFixedPart(headerLvalue) + variableFieldSize;
    lastBitNeeded = this.nextBitIndex + bitsToExtract;
    ParserModel.verify(this.lengthInBits >= lastBitNeeded, error.PacketTooShort);
@@ -5158,8 +5158,8 @@ given in pseudo-code as follows:
 
 ~ Begin P4Pseudo
 void packet_in.advance(bit<32> bits) {
-   // implementations _may_ include the following line, but need not
-   verify(bits[2:0] == 0, error.ParserInvalidAlignment);
+   // implementations are allowed to include the following line, but need not
+   // verify(bits[2:0] == 0, error.ParserInvalidArgument);
    lastBitNeeded = this.nextBitIndex + bits;
    ParserModel.verify(this.lengthInBits >= lastBitNeeded, error.PacketTooShort);
    this.nextBitIndex += bits;
@@ -7095,8 +7095,8 @@ error {
     StackOutOfBounds,  /// Reference to invalid element of a header stack.
     HeaderTooShort,    /// Extracting too many bits into a varbit field.
     ParserTimeout,     /// Parser execution time limit exceeded.
-    ParserInvalidAlignment  /// extract or advance would leave parser with
-                       /// alignment unsupported by the implementation.
+    ParserInvalidArgument  /// parser operation was called with a value
+                       /// not supported by the implementation
 }
 extern packet_in {
     /// Read a header from the packet into a fixed-sized header @hdr


### PR DESCRIPTION
…gnment

Similar to the existing statement that some implemtations are allowed
to restrict headers to be multiples of 8 bits long, such
implementations are also likely to impose similar restrictions on the
2-argument extract and advance calls, so that the parsing 'cursor' is
always at a multiple of 8 bits from the beginning of the packet.
These changes propose a way to make that explicit in the
specification.