### PR TITLE
Issue #761: Add support for the apply() miss field

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6035,7 +6035,8 @@ struct apply_result(T) {
 ~ End P4Pseudo
 
 The evaluation of the `apply` method sets the `hit` field to `true`
-and the field `miss` to `false` if a match is found in the lookup-table.
+and the field `miss` to `false` if a match is found in the lookup-table;
+if a match is not found `hit` is set to `false` and `miss` to `true`.
 These bits can be used to drive the execution of the control-flow in the
 control block that invoked the table:
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -7130,6 +7130,7 @@ The P4 compiler should provide:
 
 ## Summary of changes made in version 1.2.0
 
+* Added `table.apply().miss`
 * Allow 1-bit signed values
 * Define the type of bit slices from signed and unsigned values to be unsigned.
 * Constrain `default` label position for `switch` statements.

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6035,15 +6035,19 @@ struct apply_result(T) {
 ~ End P4Pseudo
 
 The evaluation of the `apply` method sets the `hit` field to `true`
-if a match is found in the lookup-table. This bit can be used to drive
-the execution of the control-flow in the control block that invoked
-the table:
+and the field `miss` to `false` if a match is found in the lookup-table.
+These bits can be used to drive the execution of the control-flow in the
+control block that invoked the table:
 
 ~ Begin P4Example
 if (ipv4_match.apply().hit) {
     // there was a hit
 } else {
     // there was a miss
+}
+
+if (ipv4_host.apply().miss) {
+    ipv4_lpm.apply(); // Lookup the route only if host table missed
 }
 ~ End P4Example
 


### PR DESCRIPTION
This is a small change to the spec that allows table.apply().miss in addition to table.apply().hit