### PR TITLE
Update links for string type

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1858,7 +1858,7 @@ description files; P4 programmers cannot declare new match kinds.
 The Boolean type `bool` contains just two values, `false` and `true`.
 Boolean values are not integers or bit-strings.
 
-### Strings { #sec-strings }
+### Strings { #sec-string-type }
 
 The type `string` represents strings.  There are no operations on
 string values; one cannot declare variables with a `string` type.
@@ -7247,7 +7247,7 @@ The P4 compiler should provide:
 ## Summary of changes made in version 1.2.0
 
 * Added `table.apply().miss` (Section [#sec-invoke-mau]).
-* Added `string` type (Section [#sec-string]).
+* Added `string` type (Section [#sec-string-type]).
 * Added implicit casts from enum values (Section [#sec-enum-exprs]).
 * Allow 1-bit signed values
 * Define the type of bit slices from signed and unsigned values to be unsigned.


### PR DESCRIPTION
* For consistency, rename #sec-strings to #sec-string-type

* Fix broken link to #sec-string section in description of v1.2.0
  changes, by making it point to #sec-string-type