### PR TITLE
Add optional match kind

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1844,6 +1844,7 @@ The P4 core library contains the following match_kind declaration:
 ~ Begin P4Example
 match_kind {
    exact,
+   optional,
    ternary,
    lpm
 }
@@ -5809,6 +5810,7 @@ The P4 core library contains three predefined `match_kind` identifiers:
 ~ Begin P4Example
 match_kind {
    exact,
+   optional,
    ternary,
    lpm
 }
@@ -7388,6 +7390,8 @@ action NoAction() {}
 match_kind {
     /// Match bits exactly.
     exact,
+    /// Optional match, either matches bits exactly, or behaves like a wildcard.
+    optional,
     /// Ternary match, using a mask.
     ternary,
     /// Longest-prefix match.


### PR DESCRIPTION
PR for #794. It seems like there are various people who like the proposal, and the only concern is around whether architectures can actually implement it.  Since ternary is already in core.p4, and ternary is strictly more difficult to implement/support (as jafingerhut@ nicely points out), which should address that concern.  I'm making a concrete pull request to see if there are any other concerns, and if not, so that we can move ahead and merge it.