### PR TITLE
Clean up tokens in expression grammar

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2957,10 +2957,6 @@ operators cannot be applied to boolean types.
 Concatenation (`++`) has the same precedence as infix
 addition. Bit-slicing `a[m:l]` has the same precedence as array
 indexing (`a[i]`).
-An additional semantic check is required for right shift to check
-that there is no space between the two consecutive greater-than signs `>>`.
-This rule is required to allow parsing for both the right
-shift operators and specialized types, such as in `function<bit<32>>`.
 
 In addition to these expressions, P4 also supports `select` expressions (described
 in Section [#sec-select]), which may be used only in parsers.

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -707,15 +707,15 @@ lvalue
 %left ','
 %nonassoc '?'
 %nonassoc ':'
-%left OR
-%left AND
-%left EQ NE
-%left '<' '>' LE GE
+%left '||'
+%left '&&'
+%left '==' '!='
+%left '<' '>' '<=' '>='
 %left '|'
 %left '^'
 %left '&'
-%left SHL
-%left PP '+' '-' '|+|' '|-|'
+%left '<<' '>>'
+%left '++' '+' '-' '|+|' '|-|'
 %left '*' '/' '%'
 %right PREFIX
 %nonassoc ']' '(' '['
@@ -735,10 +735,10 @@ expression
     | '{' expressionList '}'
     | '{' kvList '}'
     | '(' expression ')'
-    | '!' expression
-    | '~' expression
-    | '-' expression
-    | '+' expression
+    | '!' expression %prec PREFIX
+    | '~' expression %prec PREFIX
+    | '-' expression %prec PREFIX
+    | '+' expression %prec PREFIX
     | typeName '.' member
     | ERROR '.' member
     | expression '.' member
@@ -749,20 +749,20 @@ expression
     | expression '-' expression
     | expression '|+|' expression
     | expression '|-|' expression
-    | expression SHL expression        // <<
-    | expression '>''>' expression     // check that >> are adjacent
-    | expression LE expression         // <=
-    | expression GE expression         // >=
+    | expression '<<' expression
+    | expression '>>' expression
+    | expression '<=' expression
+    | expression '>=' expression
     | expression '<' expression
     | expression '>' expression
-    | expression NE expression         // !=
-    | expression EQ expression         // ==
+    | expression '!=' expression
+    | expression '==' expression
     | expression '&' expression
     | expression '^' expression
     | expression '|' expression
-    | expression PP expression         // ++
-    | expression AND expression        // &&
-    | expression OR expression         // ||
+    | expression '++' expression
+    | expression '&&' expression
+    | expression '||' expression
     | expression '?' expression ':' expression
     | expression '<' realTypeArgumentList '>' '(' argumentList ')'
     | expression '(' argumentList ')'


### PR DESCRIPTION
- all operator tokens as literals rather than some as names
- precedence is specified by yacc-%left/%right rules, so use consistent
  %prec modifiers in the rules.