### PR TITLE
Add '0d' syntax for decimal literals

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1266,11 +1266,12 @@ There are two Boolean literal constants: `true` and `false`.
 #### Integer literals { #sec-integer-literals }
 
 Integer literals are positive, arbitrary-precision integers. By
-default, literals are represented in base 10. To use a different base for
-the literal, one of the following prefixes must be employed:
+default, literals are represented in base 10. The following prefixes
+must be employed to specify the base explicitly:
 
 - `0x` or `0X` indicates base 16 (hexadecimal)
 - `0o` or `0O` indicates base 8 (octal)
+- `0d` or `0D` indicates base 10 (decimal)
 - `0b` or `0B` indicates base 2
 
 The width of a numeric literal in bits can be specified by an unsigned
@@ -1290,7 +1291,9 @@ integer literal. No comments or whitespaces are allowed within a
 literal. Here are some examples of numeric literals:
 
 ~ Begin P4Example
-32w0xFF        // a 32-bit unsigned number with value 255
+32w255         // a 32-bit unsigned number with value 255
+32w0d255       // same value as above
+32w0xFF        // same value as above
 32s0xFF        // a 32-bit signed number with value 255
 8w0b10101010   // an 8-bit unsigned number with value 0xAA
 8w0b_1010_1010 // same value as above


### PR DESCRIPTION
This PR fixes a mismatch between the compiler (see p4lang/p4c#2301) and the specification. It seems to have been an oversight.