### PR TITLE
Explicitly allow implicit casts for direction 'in' arguments

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4337,9 +4337,10 @@ f(y = ya, x = xa);  // match arguments by name in any order
 
 The calling convention is copy-in/copy-out (Section
 [#sec-calling-convention]).  For generic functions the type arguments
-can be explicitly specified in the function call. The compiler does
-not insert implicit casts for the arguments to methods or
-functions---the argument types must match the parameter types exactly.
+can be explicitly specified in the function call. The compiler only
+inserts implicit casts for direction `in` arguments to methods or
+functions as described in Section [#sec-casts].  The types for all
+other arguments must match the parameter types exactly.
 
 The result returned by a function call is discarded when the function
 call is used as a statement.


### PR DESCRIPTION
Intended to address issue https://github.com/p4lang/p4-spec/issues/842