### PR TITLE
Tuple fields

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -7971,6 +7971,7 @@ The P4 compiler should provide:
 
 ## Summary of changes made in version 1.3.0
 
+* support for tuple field access (Section [#sec-tuple-exprs]).
 * Support for generic structures (Section [#sec-type-spec]).
 * Generalize `switch` statements to allow expressions with integer,
   `enum`, or `error` types (Section [#sec-switch-stmt]).

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3749,7 +3749,7 @@ list expressions.
 tuple<bit<32>, bool> x = { 10, false };
 ~ End P4Example
 
-The fields of a tuple can be accessed using array index sytnax `x[0]`,
+The fields of a tuple can be accessed using array index syntax `x[0]`,
 `x[1]`.  The array indexes *must* be compile-time constants, to enable
 the type-checker to identify the field types statically.
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2488,7 +2488,7 @@ struct Parsed_headers {
 ### Tuple types { #sec-tuple-types }
 
 A tuple is similar to a `struct`, in that it holds multiple
-values. Unlike a `struct` type, tuples have no named fields. The
+values. The fields of a tuple are named in order `f0`, `f1`, etc.. The
 type of tuples with n component types `T1`,...,`Tn` is written
 as
 
@@ -3750,6 +3750,9 @@ list expressions.
 ~ Begin P4Example
 tuple<bit<32>, bool> x = { 10, false };
 ~ End P4Example
+
+The fields of a tuple are named `f0`, `f1`, etc,; they can be
+extracted using the same syntax as structure fields: `x.f0`.
 
 ## Operations on lists { #sec-list-exprs }
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2487,10 +2487,8 @@ struct Parsed_headers {
 
 ### Tuple types { #sec-tuple-types }
 
-A tuple is similar to a `struct`, in that it holds multiple
-values. The fields of a tuple are named in order `f0`, `f1`, etc.. The
-type of tuples with n component types `T1`,...,`Tn` is written
-as
+A tuple is similar to a `struct`, in that it holds multiple values.
+The type of tuples with n component types `T1`,...,`Tn` is written as
 
 ~ Begin P4Example
 tuple<T1,/* more fields omitted */,Tn>
@@ -3751,8 +3749,14 @@ list expressions.
 tuple<bit<32>, bool> x = { 10, false };
 ~ End P4Example
 
-The fields of a tuple are named `f0`, `f1`, etc,; they can be
-extracted using the same syntax as structure fields: `x.f0`.
+The fields of a tuple can be accessed using array index sytnax `x[0]`,
+`x[1]`.  The array indexes *must* be compile-time constants, to enable
+the type-checker to identify the field types statically.
+
+Currently tuple fields are not left-values, even if the tuple itself
+is.  (I.e. a tuple can only be assigned monolithically, and the field
+values cannot be changed individually.)  This restriction may be
+lifted in a future version of the language.
 
 ## Operations on lists { #sec-list-exprs }
 


### PR DESCRIPTION
This small PR introduces tuple field extraction. Initially I was thinking to use a syntax like `t.0` to extract a field, but using `t.f0` seems equally good and requires no changes to the grammar, and will not introduce ambiguities.