### PR TITLE
Possible updates/corrections to P4_16 spec grammar

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2636,22 +2636,14 @@ These declarations describe two objects:
 ### Extern types { #sec_extern }
 
 []{tex-cmd: "\indent"}
-P4 supports extern object declarations, extern function declarations, and forward extern declarations using the following syntax.
+P4 supports extern object declarations and extern function declarations using the following syntax.
 
 ~ Begin P4Grammar
 externDeclaration
     : optAnnotations EXTERN nonTypeName optTypeParameters '{' methodPrototypes '}'
     | optAnnotations EXTERN functionPrototype ';'
-    | optAnnotations EXTERN name ';'
     ;
 ~ End P4Grammar
-
-The last case is a forward extern declaration, intended for declaring
-the name of an extern object type.  Such a name can be used in later
-declarations, without first having to provide the full extern object
-declaration.  The full extern object declaration must appear later in
-the program.
-
 
 #### Extern functions
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2636,7 +2636,7 @@ These declarations describe two objects:
 ### Extern types { #sec_extern }
 
 []{tex-cmd: "\indent"}
-P4 supports extern object declarations and extern function declarations using the following syntax.
+P4 supports extern object declarations, extern function declarations, and forward extern declarations using the following syntax.
 
 ~ Begin P4Grammar
 externDeclaration
@@ -2645,6 +2645,13 @@ externDeclaration
     | optAnnotations EXTERN name ';'
     ;
 ~ End P4Grammar
+
+The last case is a forward extern declaration, intended for declaring
+the name of an extern object type.  Such a name can be used in later
+declarations, without first having to provide the full extern object
+declaration.  The full extern object declaration must appear later in
+the program.
+
 
 #### Extern functions
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2173,7 +2173,7 @@ An enumeration type is defined using the following syntax:
 ~ Begin P4Grammar
 enumDeclaration
     : optAnnotations ENUM name '{' identifierList '}'
-    | optAnnotations ENUM BIT '<' INTEGER '>' name '{' specifiedIdentifierList '}'
+    | optAnnotations ENUM typeRef name '{' specifiedIdentifierList '}'
     ;
 
 identifierList
@@ -2642,6 +2642,7 @@ P4 supports extern object declarations and extern function declarations using th
 externDeclaration
     : optAnnotations EXTERN nonTypeName optTypeParameters '{' methodPrototypes '}'
     | optAnnotations EXTERN functionPrototype ';'
+    | optAnnotations EXTERN name ';'
     ;
 ~ End P4Grammar
 
@@ -3057,6 +3058,7 @@ typeArg
     : DONTCARE
     | typeRef
     | nonTypeName
+    | VOID
     ;
 
 typeArgumentList
@@ -4439,6 +4441,7 @@ realTypeArgumentList
 realTypeArg
     : DONTCARE
     | typeRef
+    | VOID
     ;
 ~ End P4Grammar
 
@@ -6116,7 +6119,7 @@ tablePropertyList
 tableProperty
     : KEY '=' '{' keyElementList '}'
     | ACTIONS '=' '{' actionList '}'
-    | CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
+    | optAnnotations CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
     | optAnnotations CONST nonTableKwName '=' initializer ';'
     | optAnnotations nonTableKwName '=' initializer ';'
     ;

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -656,7 +656,6 @@ annotationToken
     | STRUCT
     | SWITCH
     | TABLE
-    | THIS
     | TRANSITION
     | TRUE
     | TUPLE
@@ -747,7 +746,6 @@ expression
     | TRUE
     | FALSE
     | STRING_LITERAL
-    | THIS
     | nonTypeName
     | dotPrefix nonTypeName
     | expression '[' expression ']'
@@ -795,7 +793,6 @@ nonBraceExpression
     | TRUE
     | FALSE
     | STRING_LITERAL
-    | THIS
     | nonTypeName
     | dotPrefix nonTypeName
     | nonBraceExpression '[' expression ']'

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -239,6 +239,7 @@ controlBody
 externDeclaration
     : optAnnotations EXTERN nonTypeName optTypeParameters '{' methodPrototypes '}'
     | optAnnotations EXTERN functionPrototype ';'
+    | optAnnotations EXTERN name ';'
     ;
 
 methodPrototypes
@@ -253,6 +254,7 @@ functionPrototype
 methodPrototype
     : optAnnotations functionPrototype ';'
     | optAnnotations TYPE_IDENTIFIER '(' parameterList ')' ';'
+    | optAnnotations ABSTRACT functionPrototype ';'
     ;
 
 /************************** TYPES ****************************/
@@ -295,6 +297,7 @@ specializedType
 baseType
     : BOOL
     | ERROR
+    | STRING
     | INT
     | BIT
     | BIT '<' INTEGER '>'
@@ -328,12 +331,15 @@ typeParameterList
 realTypeArg
     : DONTCARE
     | typeRef
+    | VOID
     ;
 
 typeArg
     : DONTCARE
     | typeRef
     | nonTypeName
+        // This is necessary because template arguments may introduce the return type
+    | VOID
     ;
 
 realTypeArgumentList
@@ -385,7 +391,7 @@ structField
 
 enumDeclaration
     : optAnnotations ENUM name '{' identifierList '}'
-    | optAnnotations ENUM BIT '<' INTEGER '>' name '{' specifiedIdentifierList '}'
+    | optAnnotations ENUM typeRef name '{' specifiedIdentifierList '}'
     ;
 
 errorDeclaration
@@ -507,7 +513,7 @@ tablePropertyList
 tableProperty
     : KEY '=' '{' keyElementList '}'
     | ACTIONS '=' '{' actionList '}'
-    | CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
+    | optAnnotations CONST ENTRIES '=' '{' entriesList '}' /* immutable entries */
     | optAnnotations CONST nonTableKwName '=' initializer ';'
     | optAnnotations nonTableKwName '=' initializer ';'
     ;
@@ -608,6 +614,7 @@ annotationBody
     : /* empty */
     | annotationBody '(' annotationBody ')'
     | annotationBody annotationToken
+    ;
 
 structuredAnnotationBody
     : expressionList
@@ -647,6 +654,7 @@ annotationToken
     | RETURN
     | SELECT
     | STATE
+    | STRING
     | STRUCT
     | SWITCH
     | TABLE
@@ -712,6 +720,7 @@ prefixedNonTypeName
 
 lvalue
     : prefixedNonTypeName
+    | THIS
     | lvalue '.' member
     | lvalue '[' expression ']'
     | lvalue '[' expression ':' expression ']'
@@ -741,6 +750,7 @@ expression
     | TRUE
     | FALSE
     | STRING_LITERAL
+    | THIS
     | nonTypeName
     | dotPrefix nonTypeName
     | expression '[' expression ']'
@@ -788,6 +798,7 @@ nonBraceExpression
     | TRUE
     | FALSE
     | STRING_LITERAL
+    | THIS
     | nonTypeName
     | dotPrefix nonTypeName
     | nonBraceExpression '[' expression ']'

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -239,7 +239,6 @@ controlBody
 externDeclaration
     : optAnnotations EXTERN nonTypeName optTypeParameters '{' methodPrototypes '}'
     | optAnnotations EXTERN functionPrototype ';'
-    | optAnnotations EXTERN name ';'
     ;
 
 methodPrototypes

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -254,7 +254,6 @@ functionPrototype
 methodPrototype
     : optAnnotations functionPrototype ';'
     | optAnnotations TYPE_IDENTIFIER '(' parameterList ')' ';'
-    | optAnnotations ABSTRACT functionPrototype ';'
     ;
 
 /************************** TYPES ****************************/
@@ -338,7 +337,6 @@ typeArg
     : DONTCARE
     | typeRef
     | nonTypeName
-        // This is necessary because template arguments may introduce the return type
     | VOID
     ;
 
@@ -720,7 +718,6 @@ prefixedNonTypeName
 
 lvalue
     : prefixedNonTypeName
-    | THIS
     | lvalue '.' member
     | lvalue '[' expression ']'
     | lvalue '[' expression ':' expression ']'


### PR DESCRIPTION
I found a few differences between the latest p4lang/p4c P4_16 grammar, as compared to the grammar.mdk file in the P4_16 spec repository, when reviewing another issue on the spec recently.

I suspect that some of these differences might be due to experimental features in p4c, but some of them look like things we might want to update in the spec's grammar.mdk file.  Happy to get comments about which differences are in which category, and update this PR.