### PR TITLE
Fix typo

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3689,7 +3689,7 @@ The following casts are legal in P4:
 - `bit<W> -> int<W>`: preserves all bits unchanged and reinterprets values whose most-significant bit is `1` as negative values
 - `bit<W> -> bit<X>`: truncates the value if `W > X`, and otherwise (i.e., if  `W <= X`) pads the value with zero bits.
 - `int<W> -> int<X>`: truncates the value if `W > X`, and otherwise (i.e., if `W < X`) extends it with the sign bit.
-- `bit<W> -> int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result is alwasy positive
+- `bit<W> -> int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result is always positive
 - `int<W> -> int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result may be negative
 - `int -> bit<W>`: converts the integer value into a sufficiently
   large two's complement bit string to avoid information loss, and


### PR DESCRIPTION
s/alwasy/always/ in 8.9.1 (explicit casts)