### PR TITLE
Allow switch statements in actions

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6169,9 +6169,10 @@ table entries (e.g., as specified by the control plane, the
 property).
 
 The body of an action consists of a sequence of statements and
-declarations. No `switch` statements are allowed within an
-action---the grammar permits them, but a semantic check should reject
-them. Some targets may impose additional restrictions on action
+declarations.  No `table`, `control`, or `parser` applications can
+appear within actions.
+
+Some targets may impose additional restrictions on action
 bodies---e.g., only allowing straight-line code, with no conditional
 statements or expressions.
 
@@ -8081,11 +8082,11 @@ The P4 compiler should provide:
 |           |               | semantics of invalid header stacks; clarified initialization      |
 |           |               | semantics; fixed several small issues in grammar.                 |
 |-----|-----|-----|
-| 1.2.2     | May 17, 2021 | Added support for tuple access, generic structures, additional     | 
-|           |              | enumeration types, abstract methods, conditional and empty         | 
-|           |              | statements in parsers, additional casts, and 0-width types;        | 
+| 1.2.2     | May 17, 2021 | Added support for tuple access, generic structures, additional     |
+|           |              | enumeration types, abstract methods, conditional and empty         |
+|           |              | statements in parsers, additional casts, and 0-width types;        |
 |           |              | clarified semantics of default actions, headers, empty types, and  |
-|           |              | action data; fixed typos and inconsistencies in the grammar.       | 
+|           |              | action data; fixed typos and inconsistencies in the grammar.       |
 |-----|-----|-----|
 
 ## Summary of changes made in version 1.2.2


### PR DESCRIPTION
Since we made switch statements more general we should allow them in actions.
By forbidding table applications we are more precise.