### PR TITLE
Make psa.p4 include file in spec repo explicitly not compilable

### DIFF
--- a/p4-16/psa/examples/psa-example-bridged-metadata.p4
+++ b/p4-16/psa/examples/psa-example-bridged-metadata.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-clone-to-port.p4
+++ b/p4-16/psa/examples/psa-example-clone-to-port.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 typedef bit<48>  EthernetAddress;
 

--- a/p4-16/psa/examples/psa-example-counters.p4
+++ b/p4-16/psa/examples/psa-example-counters.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-digest.p4
+++ b/p4-16/psa/examples/psa-example-digest.p4
@@ -23,7 +23,14 @@ limitations under the License.
  */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 typedef bit<48>  EthernetAddress;
 

--- a/p4-16/psa/examples/psa-example-drop-all.p4
+++ b/p4-16/psa/examples/psa-example-drop-all.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-hello-world.p4
+++ b/p4-16/psa/examples/psa-example-hello-world.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-incremental-checksum.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-incremental-checksum2.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum2.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-mirror-on-drop.p4
+++ b/p4-16/psa/examples/psa-example-mirror-on-drop.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 typedef bit<48>  EthernetAddress;
 

--- a/p4-16/psa/examples/psa-example-parser-checksum.p4
+++ b/p4-16/psa/examples/psa-example-parser-checksum.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-parser-error-handling.p4
+++ b/p4-16/psa/examples/psa-example-parser-error-handling.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 // This program is very similar in behavior to
 // psa-example-parser-checksum.p4, and was originally copied from that

--- a/p4-16/psa/examples/psa-example-parser-error-handling2.p4
+++ b/p4-16/psa/examples/psa-example-parser-error-handling2.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 // This program is very similar in behavior to
 // psa-example-parser-checksum.p4, and was originally copied from that

--- a/p4-16/psa/examples/psa-example-recirculate.p4
+++ b/p4-16/psa/examples/psa-example-recirculate.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 typedef bit<48>  EthernetAddress;
 

--- a/p4-16/psa/examples/psa-example-register1.p4
+++ b/p4-16/psa/examples/psa-example-register1.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-register2.p4
+++ b/p4-16/psa/examples/psa-example-register2.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 
 typedef bit<48>  EthernetAddress;

--- a/p4-16/psa/examples/psa-example-resubmit.p4
+++ b/p4-16/psa/examples/psa-example-resubmit.p4
@@ -15,7 +15,14 @@ limitations under the License.
 */
 
 #include <core.p4>
-#include "../psa.p4"
+/* In a normal PSA program the next line would be:
+
+#include <psa.p4>
+
+ * These examples use psa-for-bmv2.p4 instead so that it is convenient
+ * to test compiling these PSA example programs with local changes to
+ * the psa-for-bmv2.p4 file. */
+#include "psa-for-bmv2.p4"
 
 typedef bit<48>  EthernetAddress;
 

--- a/p4-16/psa/examples/psa-for-bmv2.p4
+++ b/p4-16/psa/examples/psa-for-bmv2.p4
@@ -27,14 +27,12 @@ limitations under the License.
 
 /* Target device for which this section is customized:
  *
- * This file is only intended for the purpose of including parts of it
- * in the PSA specification document.  It is not intended to be
- * compiled.
+ * BMv2 PSA as implemented by the psa_switch software switch from the
+ * repository https://github.com/p4lang/behavioral-model
  *
- * For examples of psa.p4 include files customized for their P4
- * targets, see p4include/bmv2/psa.p4 and p4include/dpdk/psa.p4 in the
- * https://github.com/p4lang/p4c repository. */
-#error "This file is for documentation purposes only and is not intended to be compiled"
+ * The bit widths for BMv2 psa_switch have been chosen to be the same
+ * as the corresponding InHeader types later.  This simplifies the
+ * implementation of P4Runtime for BMv2 psa_switch. */
 
 // BEGIN:Type_defns
 /* These are defined using `typedef`, not `type`, so they are truly
@@ -51,13 +49,22 @@ limitations under the License.
  *
  * Note that the width of typedef <name>Uint_t will always be the same
  * as the width of type <name>_t. */
-typedef bit<unspecified> PortIdUint_t;
-typedef bit<unspecified> MulticastGroupUint_t;
-typedef bit<unspecified> CloneSessionIdUint_t;
-typedef bit<unspecified> ClassOfServiceUint_t;
-typedef bit<unspecified> PacketLengthUint_t;
-typedef bit<unspecified> EgressInstanceUint_t;
-typedef bit<unspecified> TimestampUint_t;
+typedef bit<32> PortIdUint_t;
+typedef bit<32> MulticastGroupUint_t;
+typedef bit<16> CloneSessionIdUint_t;
+typedef bit<8>  ClassOfServiceUint_t;
+typedef bit<16> PacketLengthUint_t;
+typedef bit<16> EgressInstanceUint_t;
+typedef bit<64> TimestampUint_t;
+
+/* Note: clone_spec in BMv2 simple_switch v1model is 32 bits wide, but
+ * it is used such that 16 of its bits contain a clone/mirror session
+ * id, and 16 bits contain the numeric id of a field_list.  Only the
+ * 16 bits of clone/mirror session id are comparable to the type
+ * CloneSessionIdUint_t here.  See occurrences of clone_spec in this
+ * file for details:
+ * https://github.com/p4lang/behavioral-model/blob/main/targets/simple_switch/simple_switch.cpp
+ */
 
 @p4runtime_translation("p4.org/psa/v1/PortId_t", 32)
 type PortIdUint_t         PortId_t;
@@ -75,10 +82,10 @@ type EgressInstanceUint_t EgressInstance_t;
 type TimestampUint_t      Timestamp_t;
 typedef error   ParserError_t;
 
-const PortId_t PSA_PORT_RECIRCULATE = (PortId_t) unspecified;
-const PortId_t PSA_PORT_CPU = (PortId_t) unspecified;
+const PortId_t PSA_PORT_RECIRCULATE = (PortId_t) 0xfffffffa;
+const PortId_t PSA_PORT_CPU = (PortId_t) 0xfffffffd;
 
-const CloneSessionId_t PSA_CLONE_SESSION_TO_CPU = (CloneSessiontId_t) unspecified;
+const CloneSessionId_t PSA_CLONE_SESSION_TO_CPU = (CloneSessionId_t) 0;
 // END:Type_defns
 
 /**********************************************************************


### PR DESCRIPTION
Before this change,the p4-16/psa/psa.p4 include file contained a mix
of one section intended to be an example for a BMv2 target-specific
psa.p4 include file, and also a section with 'unspecified' for several
bit widths intended for generating the PSA specification text.

With this change, that file is only for the purpose of generating the
PSA specification.  It is no longer compilable, and contains an #error
directive that should make this obvious to anyone who tries to include
it while compiling a P4 program.  It also has comments linking to two
compilable example target-specific psa.p4 include files in the
p4lang/p4c repository.

Add a copy of the compilable version of the BMv2-specific psa.p4
include file in p4-16/psa/examples/psa-for-bmv2.p4, simply so the
example PSA programs can include that version.  Keeping it separate in
this repository makes it straightforward to do experimental local
changes in this repo.

Remove include of core.p4 from psa.p4.  This should be unnecessary
given that all example programs for other architectures recommend
first including core.p4, then the architecture's header file.

Add @pure and @noSideEffect annotations to match the ones used by
psa.p4 include files in open source p4c compiler.