### PR TITLE
psa: Update comment about PNA

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -68,10 +68,10 @@ the APIs and guidelines here, developers will be able to write P4
 programs that are portable across many devices that are conformant to
 the PSA.
 
-While parts of PSA are specific to network switches, and a "Portable
-NIC Architecture" (if such a thing is developed) would differ
-significantly from PSA in those parts, we expect the externs defined
-here will be of general use across multiple P4~16~ architectures.
+While parts of PSA are specific to network switches, and the "Portable
+NIC Architecture" differs significantly from PSA in those parts, we
+expect the externs defined here will be of general use across multiple
+P4~16~ architectures.
 
 The Portable Switch Architecture (PSA) Model has six programmable P4
 blocks and two fixed-function blocks, as shown in Figure


### PR DESCRIPTION
> a "Portable NIC Architecture" (if such a thing is developed)

This comment implies that the PNA architecture specification doesn't exist yet, however, a draft version of [PNA](https://p4.org/p4-spec/docs/PNA-v0.5.0.html) (version 0.5) has been released in May 2021.
