### PR TITLE
Improve implicit casts for Issue 957

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3708,7 +3708,7 @@ The following casts are legal in P4:
 To keep the language simple and avoid introducing hidden costs, P4
 only implicitly casts from `int` to fixed-width types and from enums
 with an underlying type to the underlying type. In particular,
-applying a binary operation to an expression of type `int` and an
+applying a binary operation (except shifts and concatenation) to an expression of type `int` and an
 expression with a fixed-width type will implicitly cast the `int`
 expression to the type of the other expression.
 
@@ -3728,9 +3728,9 @@ the compiler will add implicit casts as follows:
 
 - `x + 1` becomes `x + (bit<8>)1`
 - `z < 0` becomes `z < (int<8>)0`
-- `x << 13` becomes `0`; overflow warning
 - `x | 0xFFF` becomes `x | (bit<8>)0xFFF`; overflow warning
 - `x + E.a` becomes `x + (bit<8>)E.a`
+- `x << 256` becomes `0`; no implicit cast for shifts; overflow warning
 
 ### Illegal arithmetic expressions { #sec-illegal-arith }
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3730,7 +3730,7 @@ the compiler will add implicit casts as follows:
 - `z < 0` becomes `z < (int<8>)0`
 - `x | 0xFFF` becomes `x | (bit<8>)0xFFF`; overflow warning
 - `x + E.a` becomes `x + (bit<8>)E.a`
-- `x << 256` becomes `0`; no implicit cast for shifts; overflow warning
+- `x << 256` remains unchanged; `256` not implicitly cast to `8w0` in a shift; overflow warning
 
 ### Illegal arithmetic expressions { #sec-illegal-arith }
 


### PR DESCRIPTION
- We exclude shifts and concatenation from implicit casts.
- We changed the shift example to emphasize that there is no implicit cast.

Fixes #957 