### PR TITLE
Add types with optional parameters for Issue 977

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1697,7 +1697,7 @@ directions:
 A parameter that is annotated with the `@optional` annotation is
 optional: the user may omit the value for that parameter in an
 invocation.  Optional parameters can only appear for arguments of:
-packages, extern functions, extern methods, and extern object
+packages, parser types, control types, extern functions, extern methods, and extern object
 constructors.  Optional parameters cannot have default values.  If a
 procedure-like construct has both optional parameters and default values then it
 can only be called using named arguments.  It is recommended, but not
@@ -7888,7 +7888,7 @@ annotations named like `@X_annotation`
 
 ### Optional parameter annotations { #sec-optional-parameter-annotations }
 
-A parameter to a package, extern method, extern function or extern
+A parameter to a package, parser type, control type, extern method, extern function or extern
 object constructor can be annotated with `@optional` to indicate that
 the user does not need to provide a corresponding argument for that
 parameter.  The meaning of a parameter with no supplied value is


### PR DESCRIPTION
- We added parser and control types to the types that allow optional parameters.

Fixes #977 