### PR TITLE
Remove instantiation from block for Issue 975

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5130,7 +5130,7 @@ emptyStatement
 
 A block statement is denoted by curly braces. It contains a
 sequence of statements and declarations, which are executed
-sequentially. The variables, constants, and instantiations within a
+sequentially. The variables and constants within a
 block statement are only visible within the block.
 
 ~ Begin P4Grammar
@@ -5147,7 +5147,6 @@ statementOrDeclaration
     : variableDeclaration
     | constantDeclaration
     | statement
-    | instantiation
     ;
 ~ End P4Grammar
 

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -518,7 +518,6 @@ statementOrDeclaration
     : variableDeclaration
     | constantDeclaration
     | statement
-    | instantiation
     ;
 
 /************ TABLES *************/


### PR DESCRIPTION
- We removed `instantiation` from `statementOrDeclaration` in grammar

Fixes #975 