### PR TITLE
Improve and move operations on sets for Issue 969

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3700,153 +3700,6 @@ finding this information in a section dedicated to type `varbit`.
   inserts a variable-sized bit-string with a known dynamic width into
   the packet being constructed.
 
-## Operations on sets { #sec-set-exprs }
-
-Some P4 expressions denote sets of values (`set<T>`, for some numeric type `T`;
-see Section [#sec-set-types]). These expressions can
-appear only in a few contexts---parsers and constant table
-entries.  In both cases,
-implicit casts are applied recursively to every element in the set when needed.
-For example, the `select` expression (Section
-[#sec-select]) has the following structure:
-
-~ Begin P4Example
-select (expression) {
-   set1: state1;
-   set2: state2;
-   // More labels omitted
-}
-~ End P4Example
-
-Here the expressions `set1, set2`, etc. evaluate to sets of values
-and the `select` expression tests whether `expression` belongs to
-the sets used as labels.
-
-~ Begin P4Grammar
-keysetExpression
-    : tupleKeysetExpression
-    | simpleKeysetExpression
-    ;
-
-tupleKeysetExpression
-    : "(" simpleKeysetExpression "," simpleExpressionList ")"
-    | "(" reducedSimpleKeysetExpression ")"
-    ;
-
-simpleExpressionList
-    : simpleKeysetExpression
-    | simpleExpressionList ',' simpleKeysetExpression
-    ;
-
-reducedSimpleKeysetExpression
-    : expression "&&&" expression
-    | expression ".." expression
-    | DEFAULT
-    | "_"
-    ;
-
-simpleKeysetExpression
-    : expression
-    | DEFAULT
-    | DONTCARE
-    | expression MASK expression
-    | expression RANGE expression
-    ;
-~ End P4Grammar
-
-The mask (`&&&`) and range (`..`) operators have the same
-precedence, which is just higher than `&`.
-
-### Singleton sets { #sec-singleton-set }
-
-In a set context, expressions denote singleton sets. For example, in
-the following program fragment,
-
-~ Begin P4Example
-select (hdr.ipv4.version) {
-   4: continue;
-}
-~ End P4Example
-
-The label `4` denotes the singleton set containing the `int` value `4`.
-
-### The universal set { #sec-universal-set }
-
-In a set context, the expressions `default` or `_` denote the
-universal set, which contains all possible values of a given type:
-
-~ Begin P4Example
-select (hdr.ipv4.version) {
-   4: continue;
-   _: reject;
-}
-~ End P4Example
-
-### Masks { #sec-cubes }
-
-The infix operator `&&&` takes two arguments of the same numeric type (section [#sec-numeric-values]),
-and creates a value of the same type. 
-The right value is used as a
-"mask", where each bit set to `0` in the mask indicates a "don't care"
-bit. More formally, the set denoted by `a &&& b` is defined as
-follows:
-
-~ Begin P4Example
-a &&& b = { c where a & b = c & b }
-~ End P4Example
-
-For example:
-
-~ Begin P4Example
-8w0x0A &&& 8w0x0F
-~ End P4Example
-
-denotes a set that contains 16 different `bit<8>` values, whose
-bit-pattern is `XXXX1010`, where the value of an `X` can be
-any bit. Note that there may be multiple ways to express a keyset
-using a mask operator---e.g., `8w0xFA &&& 8w0x0F` denotes the same
-keyset as in the example above.
-
-Similar to other binary operations,
-the mask operator allows the compiler to automatically insert casts
-to unify the argument types in certain situations (section [#sec-implicit-casts]).
-
-P4 architectures may impose additional restrictions on the expressions
-on the left and right-hand side of a mask operator: for example, they
-may require that either or both sub-expressions be compile-time known
-values.
-
-### Ranges { #sec-ranges }
-
-The infix operator `..` takes two arguments of the same numeric type `T` (section [#sec-numeric-values]),
-and creates a value of
-the type `set<T>`. The set contains all values numerically between the
-first and the second, inclusively. For example:
-
-~ Begin P4Example
-4s5 .. 4s8
-~ End P4Example
-
-denotes a set of 4 consecutive `int<4>` values `4s5, 4s6, 4s7`, and `4s8`.
-
-Similar to other binary operations,
-the range operator allows the compiler to automatically insert casts
-to unify the argument types in certain situations (section [#sec-implicit-casts]).
-
-### Products { #sec-tuples-of-sets }
-
-Multiple sets can be combined using Cartesian product:
-
-~ Begin P4Example
-select(hdr.ipv4.ihl, hdr.ipv4.protocol) {
-     (4w0x5, 8w0x1): parse_icmp;
-     (4w0x5, 8w0x6): parse_tcp;
-     (4w0x5, 8w0x11): parse_udp;
-     (_, _): accept; }
-~ End P4Example
-
-The type of a product of sets is a set of tuples.
-
 ## Casts { #sec-casts }
 
 P4 provides a limited set of casts between types. A cast is written
@@ -4081,6 +3934,154 @@ Structure-valued expressions can be used in the right-hand side of
 assignments, in comparisons, in field selection expressions, and as
 arguments to functions, method or actions.  Structure-valued
 expressions are not left values.
+
+## Operations on sets { #sec-set-exprs }
+
+Some P4 expressions denote sets of values (`set<T>`, for some numeric type `T`;
+see Section [#sec-set-types]). These expressions can
+appear only in a few contexts---parsers and constant table
+entries.  In both cases,
+implicit casts are applied recursively to every element in the set when needed.
+For example, the `select` expression (Section
+[#sec-select]) has the following structure:
+
+~ Begin P4Example
+select (expression) {
+   set1: state1;
+   set2: state2;
+   // More labels omitted
+}
+~ End P4Example
+
+Here the expressions `set1, set2`, etc. evaluate to sets of values
+and the `select` expression tests whether `expression` belongs to
+the sets used as labels.
+
+~ Begin P4Grammar
+keysetExpression
+    : tupleKeysetExpression
+    | simpleKeysetExpression
+    ;
+
+tupleKeysetExpression
+    : "(" simpleKeysetExpression "," simpleExpressionList ")"
+    | "(" reducedSimpleKeysetExpression ")"
+    ;
+
+simpleExpressionList
+    : simpleKeysetExpression
+    | simpleExpressionList ',' simpleKeysetExpression
+    ;
+
+reducedSimpleKeysetExpression
+    : expression "&&&" expression
+    | expression ".." expression
+    | DEFAULT
+    | "_"
+    ;
+
+simpleKeysetExpression
+    : expression
+    | DEFAULT
+    | DONTCARE
+    | expression MASK expression
+    | expression RANGE expression
+    ;
+~ End P4Grammar
+
+The mask (`&&&`) and range (`..`) operators have the same
+precedence, which is just higher than `&`.
+
+### Singleton sets { #sec-singleton-set }
+
+In a set context, expressions denote singleton sets. For example, in
+the following program fragment,
+
+~ Begin P4Example
+select (hdr.ipv4.version) {
+   4: continue;
+}
+~ End P4Example
+
+The label `4` denotes the singleton set containing the `int` value `4`.
+
+### The universal set { #sec-universal-set }
+
+In a set context, the expressions `default` or `_` denote the
+universal set, which contains all possible values of a given type:
+
+~ Begin P4Example
+select (hdr.ipv4.version) {
+   4: continue;
+   _: reject;
+}
+~ End P4Example
+
+### Masks { #sec-cubes }
+
+The infix operator `&&&` takes two arguments of the same numeric type (section [#sec-numeric-values]),
+and creates a value of the same type. 
+The right value is used as a
+"mask", where each bit set to `0` in the mask indicates a "don't care"
+bit. More formally, the set denoted by `a &&& b` is defined as
+follows:
+
+~ Begin P4Example
+a &&& b = { c where a & b = c & b }
+~ End P4Example
+
+For example:
+
+~ Begin P4Example
+8w0x0A &&& 8w0x0F
+~ End P4Example
+
+denotes a set that contains 16 different `bit<8>` values, whose
+bit-pattern is `XXXX1010`, where the value of an `X` can be
+any bit. Note that there may be multiple ways to express a keyset
+using a mask operator---e.g., `8w0xFA &&& 8w0x0F` denotes the same
+keyset as in the example above.
+
+Similar to other binary operations,
+the mask operator allows the compiler to automatically insert casts
+to unify the argument types in certain situations (section [#sec-implicit-casts]).
+
+P4 architectures may impose additional restrictions on the expressions
+on the left and right-hand side of a mask operator: for example, they
+may require that either or both sub-expressions be compile-time known
+values.
+
+### Ranges { #sec-ranges }
+
+The infix operator `..` takes two arguments of the same numeric type `T` (section [#sec-numeric-values]),
+and creates a value of
+the type `set<T>`. The set contains all values numerically between the
+first and the second, inclusively. For example:
+
+~ Begin P4Example
+4s5 .. 4s8
+~ End P4Example
+
+denotes a set of 4 consecutive `int<4>` values `4s5, 4s6, 4s7`, and `4s8`.
+
+Similar to other binary operations,
+the range operator allows the compiler to automatically insert casts
+to unify the argument types in certain situations (section [#sec-implicit-casts]).
+
+### Products { #sec-tuples-of-sets }
+
+Multiple sets can be combined using Cartesian product:
+
+~ Begin P4Example
+select(hdr.ipv4.ihl, hdr.ipv4.protocol) {
+     (4w0x5, 8w0x1): parse_icmp;
+     (4w0x5, 8w0x6): parse_tcp;
+     (4w0x5, 8w0x11): parse_udp;
+     (_, _): accept; }
+~ End P4Example
+
+The type of a product of sets is a set of tuples.
+
 
 ## Operations on struct types { #sec-ops-on-structs }
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2596,7 +2596,7 @@ types.
 
 #### Set types { #sec-set-types }
 
-The type `set<T>` describes _sets_ of values of type `T`. Set
+The type `set<T>` describes _sets_ of values of some numeric type `T` (section [#sec-numeric-values]). Set
 types can only appear in restricted contexts in P4 programs. For
 example, the range expression `8w5 .. 8w8` describes a set
 containing the 8-bit numbers 5, 6, 7, and 8, so its type is `set<bit<8>>;`.
@@ -2945,6 +2945,20 @@ as follows:
 Note that some types do not have default values, e.g., `match_kind`,
 set types, function types, extern types, parser types, control types,
 package types.
+
+## Numeric types { #sec-numeric-values }
+
+Many P4 operations are restrained to expressions that evaluate to numeric values. 
+Such expressions must have one of the following numeric types:
+
+  - `int` - an infinite-precision integer (section
+    [#sec-infinite-precision-integers])
+  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0` (section
+    [#sec-unsigned-integers])
+  - `int<W>` - a `W`-bit signed integer where `W >= 1` (section
+    [#sec-signed-integers])
+  - a serializable `enum` with an underlying type that is `bit<W>` or
+    `int<W>` (section [#sec-enum-types]).
 
 ## typedef { #sec-typedef }
 
@@ -3460,17 +3474,7 @@ Bit-strings also support the following operations:
 - Extraction of a set of contiguous bits, also known as a slice, denoted by `[m:l]`,
   where `m` and `l` must be expressions that evaluate to
   non-negative compile-time known values, and `m >= l`. The types of `m` and `l` (which do not have to be identical)
-  must be one of the following:
-
-  - `int` - an infinite-precision integer (section
-    [#sec-infinite-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0` (section
-    [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where `W >= 1` (section
-    [#sec-signed-integers])
-  - a serializable `enum` with an underlying type that is `bit<W>` or
-    `int<W>` (section [#sec-enum-types]).
-
+  must be numeric (section [#sec-numeric-values]).
   The result is a bit-string of width `m - l + 1`, including the bits numbered
   from `l` (which becomes the least significant bit of the result) to `m` (the
   most significant bit of the result) from the source operand. The conditions `0 <= l < W`
@@ -3555,17 +3559,7 @@ The `int<W>` datatype also support the following operations:
 - Extraction of a set of contiguous bits, also known as a slice, denoted by `[m:l]`,
   where `m` and `l` must be expressions that evaluate to
   non-negative compile-time known values, and `m >= l`. The types of `m` and `l` (which do not have to be identical)
-  must be one of the following:
-
-  - `int` - an infinite-precision integer (section
-    [#sec-infinite-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0` (section
-    [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where `W >= 1` (section
-    [#sec-signed-integers])
-  - a serializable `enum` with an underlying type that is `bit<W>` or
-    `int<W>` (section [#sec-enum-types]).
-
+  must be numeric (section [#sec-numeric-values]).
   The result is an unsigned bit-string of width `m - l + 1`, including the bits numbered
   from `l` (which becomes the least significant bit of the result) to `m` (the
   most significant bit of the result) from the source operand. The conditions `0 <= l < W`
@@ -3706,6 +3700,153 @@ finding this information in a section dedicated to type `varbit`.
   inserts a variable-sized bit-string with a known dynamic width into
   the packet being constructed.
 
+## Operations on sets { #sec-set-exprs }
+
+Some P4 expressions denote sets of values (`set<T>`, for some numeric type `T`;
+see Section [#sec-set-types]). These expressions can
+appear only in a few contexts---parsers and constant table
+entries.  In both cases,
+implicit casts are applied recursively to every element in the set when needed.
+For example, the `select` expression (Section
+[#sec-select]) has the following structure:
+
+~ Begin P4Example
+select (expression) {
+   set1: state1;
+   set2: state2;
+   // More labels omitted
+}
+~ End P4Example
+
+Here the expressions `set1, set2`, etc. evaluate to sets of values
+and the `select` expression tests whether `expression` belongs to
+the sets used as labels.
+
+~ Begin P4Grammar
+keysetExpression
+    : tupleKeysetExpression
+    | simpleKeysetExpression
+    ;
+
+tupleKeysetExpression
+    : "(" simpleKeysetExpression "," simpleExpressionList ")"
+    | "(" reducedSimpleKeysetExpression ")"
+    ;
+
+simpleExpressionList
+    : simpleKeysetExpression
+    | simpleExpressionList ',' simpleKeysetExpression
+    ;
+
+reducedSimpleKeysetExpression
+    : expression "&&&" expression
+    | expression ".." expression
+    | DEFAULT
+    | "_"
+    ;
+
+simpleKeysetExpression
+    : expression
+    | DEFAULT
+    | DONTCARE
+    | expression MASK expression
+    | expression RANGE expression
+    ;
+~ End P4Grammar
+
+The mask (`&&&`) and range (`..`) operators have the same
+precedence, which is just higher than `&`.
+
+### Singleton sets { #sec-singleton-set }
+
+In a set context, expressions denote singleton sets. For example, in
+the following program fragment,
+
+~ Begin P4Example
+select (hdr.ipv4.version) {
+   4: continue;
+}
+~ End P4Example
+
+The label `4` denotes the singleton set containing the `int` value `4`.
+
+### The universal set { #sec-universal-set }
+
+In a set context, the expressions `default` or `_` denote the
+universal set, which contains all possible values of a given type:
+
+~ Begin P4Example
+select (hdr.ipv4.version) {
+   4: continue;
+   _: reject;
+}
+~ End P4Example
+
+### Masks { #sec-cubes }
+
+The infix operator `&&&` takes two arguments of the same numeric type (section [#sec-numeric-values]),
+and creates a value of the same type. 
+The right value is used as a
+"mask", where each bit set to `0` in the mask indicates a "don't care"
+bit. More formally, the set denoted by `a &&& b` is defined as
+follows:
+
+~ Begin P4Example
+a &&& b = { c where a & b = c & b }
+~ End P4Example
+
+For example:
+
+~ Begin P4Example
+8w0x0A &&& 8w0x0F
+~ End P4Example
+
+denotes a set that contains 16 different 8-bit values, whose
+bit-pattern is `XXXX1010`, where the value of an `X` can be
+any bit. Note that there may be multiple ways to express a keyset
+using a mask operator---e.g., `8w0xFA &&& 8w0x0F` denotes the same
+keyset as in the example above.
+
+Similar to other binary operations,
+the mask operator allows the compiler to automatically inserts casts
+to unify the argument types in certain situations (section [#sec-implicit-casts]).
+
+P4 architectures may impose additional restrictions on the expressions
+on the left and right-hand side of a mask operator: for example, they
+may require that either or both sub-expressions be compile-time known
+values.
+
+### Ranges { #sec-ranges }
+
+The infix operator `..` takes two arguments of the same numeric type `T` (section [#sec-numeric-values]),
+and creates a value of
+the type `set<T>`. The set contains all values numerically between the
+first and the second, inclusively. For example:
+
+~ Begin P4Example
+4w5 .. 4w8
+~ End P4Example
+
+denotes a set with values `4w5, 4w6, 4w7`, and `4w8`.
+
+Similar to other binary operations,
+the range operator allows the compiler to automatically inserts casts
+to unify the argument types in certain situations (section [#sec-implicit-casts]).
+
+### Products { #sec-tuples-of-sets }
+
+Multiple sets can be combined using Cartesian product:
+
+~ Begin P4Example
+select(hdr.ipv4.ihl, hdr.ipv4.protocol) {
+     (4w0x5, 8w0x1): parse_icmp;
+     (4w0x5, 8w0x6): parse_tcp;
+     (4w0x5, 8w0x11): parse_udp;
+     (_, _): accept; }
+~ End P4Example
+
+The type of a product of sets is a set of tuples.
+
 ## Casts { #sec-casts }
 
 P4 provides a limited set of casts between types. A cast is written
@@ -3776,6 +3917,7 @@ the compiler will add implicit casts as follows:
 - `z < 0` becomes `z < (int<8>)0`
 - `x | 0xFFF` becomes `x | (bit<8>)0xFFF`; overflow warning
 - `x + E.a` becomes `x + (bit<8>)E.a`
+- `x &&& 8` becomes `x &&& (bit<8>)8`
 - `x << 256` remains unchanged; `256` not implicitly cast to `8w0` in a shift; overflow warning
 - `16w11 << E.a` becomes `16w11 << (bit<8>)E.a`
 - `x[E.a:0]` becomes `x[(bit<8>)E.a:0]`
@@ -3940,143 +4082,6 @@ assignments, in comparisons, in field selection expressions, and as
 arguments to functions, method or actions.  Structure-valued
 expressions are not left values.
 
-## Operations on sets { #sec-set-exprs }
-
-Some P4 expressions denote sets of values (`set<T>`, for some type `T`;
-see Section [#sec-set-types]). These expressions can
-appear only in a few contexts---parsers and constant table
-entries. For example, the `select` expression (Section
-[#sec-select]) has the following structure:
-
-~ Begin P4Example
-select (expression) {
-   set1: state1;
-   set2: state2;
-   // More labels omitted
-}
-~ End P4Example
-
-Here the expressions `set1, set2`, etc. evaluate to sets of values
-and the `select` expression tests whether `expression` belongs to
-the sets used as labels.
-
-~ Begin P4Grammar
-keysetExpression
-    : tupleKeysetExpression
-    | simpleKeysetExpression
-    ;
-
-tupleKeysetExpression
-    : "(" simpleKeysetExpression "," simpleExpressionList ")"
-    | "(" reducedSimpleKeysetExpression ")"
-    ;
-
-simpleExpressionList
-    : simpleKeysetExpression
-    | simpleExpressionList ',' simpleKeysetExpression
-    ;
-
-reducedSimpleKeysetExpression
-    : expression "&&&" expression
-    | expression ".." expression
-    | DEFAULT
-    | "_"
-    ;
-
-simpleKeysetExpression
-    : expression
-    | DEFAULT
-    | DONTCARE
-    | expression MASK expression
-    | expression RANGE expression
-    ;
-~ End P4Grammar
-
-The mask (`&&&`) and range (`..`) operators have the same
-precedence, which is just higher than `&`.
-
-### Singleton sets { #sec-singleton-set }
-
-In a set context, expressions denote singleton sets. For example, in
-the following program fragment,
-
-~ Begin P4Example
-select (hdr.ipv4.version) {
-   4: continue;
-}
-~ End P4Example
-
-The label `4` is denotes the singleton set containing `4`.
-
-### The universal set { #sec-universal-set }
-
-In a set context, the expressions `default` or `_` denote the
-universal set, which contains all possible values of a given type:
-
-~ Begin P4Example
-select (hdr.ipv4.version) {
-   4: continue;
-   _: reject;
-}
-~ End P4Example
-
-### Masks { #sec-cubes }
-
-The infix operator `&&&` takes two arguments of type `bit<W>` or
-serializable `enum`, and creates a value of type `set<ltype>`, where
-ltype is the type of the left argument.  The right value is used as a
-"mask", where each bit set to `0` in the mask indicates a "don't care"
-bit. More formally, the set denoted by `a &&& b` is defined as
-follows:
-
-~ Begin P4Example
-a &&& b = { c of type bit<W> where a & b = c & b }
-~ End P4Example
-
-For example:
-
-~ Begin P4Example
-8w0x0A &&& 8w0x0F
-~ End P4Example
-
-denotes a set that contains 16 different 8-bit values, whose
-bit-pattern is `XXXX1010`, where the value of an `X` can be
-any bit. Note that there may be multiple ways to express a keyset
-using a mask operator---e.g., `8w0xFA &&& 8w0x0F` denotes the same
-keyset as in the example above.
-
-P4 architectures may impose additional restrictions on the expressions
-on the left and right-hand side of a mask operator: for example, they
-may require that either or both sub-expressions be compile-time known
-values.
-
-### Ranges { #sec-ranges }
-
-The infix operator `..` takes two arguments of the same type `T`,
-where `T` is either `bit<W>` or `int<W>`, and creates a value of
-type `set<T>`. The set contains all values numerically between the
-first and the second, inclusively. For example:
-
-~ Begin P4Example
-4w5 .. 4w8
-~ End P4Example
-
-denotes a set with values `4w5, 4w6, 4w7`, and `4w8`.
-
-### Products { #sec-tuples-of-sets }
-
-Multiple sets can be combined using Cartesian product:
-
-~ Begin P4Example
-select(hdr.ipv4.ihl, hdr.ipv4.protocol) {
-     (4w0x5, 8w0x1): parse_icmp;
-     (4w0x5, 8w0x6): parse_tcp;
-     (4w0x5, 8w0x11): parse_udp;
-     (_, _): accept; }
-~ End P4Example
-
-The type of a product of sets is a set of tuples.
-
 ## Operations on struct types { #sec-ops-on-structs }
 
 The only operation defined on expressions whose type is a `struct` is
@@ -4196,16 +4201,7 @@ expressions are legal:
   [#sec-uninitialized-values-and-writing-invalid-headers] for more
   details.
 
-  The `index` is an expression that must be one of the following types:
-
-  - `int` - an infinite-precision integer (section
-    [#sec-infinite-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0` (section
-    [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where `W >= 1` (section
-    [#sec-signed-integers])
-  - a serializable `enum` with an underlying type that is `bit<W>` or
-    `int<W>` (section [#sec-enum-types]).
+  The `index` is an expression that must be of numeric types (section [#sec-numeric-values]).
 
 - `hs.size`: produces a 32-bit unsigned integer that returns the
   size of the header stack (a compile-time constant).

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3801,14 +3801,14 @@ For example:
 8w0x0A &&& 8w0x0F
 ~ End P4Example
 
-denotes a set that contains 16 different 8-bit values, whose
+denotes a set that contains 16 different `bit<8>` values, whose
 bit-pattern is `XXXX1010`, where the value of an `X` can be
 any bit. Note that there may be multiple ways to express a keyset
 using a mask operator---e.g., `8w0xFA &&& 8w0x0F` denotes the same
 keyset as in the example above.
 
 Similar to other binary operations,
-the mask operator allows the compiler to automatically inserts casts
+the mask operator allows the compiler to automatically insert casts
 to unify the argument types in certain situations (section [#sec-implicit-casts]).
 
 P4 architectures may impose additional restrictions on the expressions
@@ -3824,13 +3824,13 @@ the type `set<T>`. The set contains all values numerically between the
 first and the second, inclusively. For example:
 
 ~ Begin P4Example
-4w5 .. 4w8
+4s5 .. 4s8
 ~ End P4Example
 
-denotes a set with values `4w5, 4w6, 4w7`, and `4w8`.
+denotes a set of 4 consecutive `int<4>` values `4s5, 4s6, 4s7`, and `4s8`.
 
 Similar to other binary operations,
-the range operator allows the compiler to automatically inserts casts
+the range operator allows the compiler to automatically insert casts
 to unify the argument types in certain situations (section [#sec-implicit-casts]).
 
 ### Products { #sec-tuples-of-sets }


### PR DESCRIPTION
- We added a section to define _numeric types_, which is later referred to when defining the argument types of sets and indexes.
- We clarified the implicit casts of both set types and set operations.
- We added examples of implicit casts for set operations in implicit casts.
- We moved the section of _Operations on sets_ before the section of _Casts_.
- We adapted an existing example to generate a set of `int<W>`.

Fixes #969