### PR TITLE
match_kind is a base type

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1828,6 +1828,7 @@ P4 supports the following built-in base types:
 baseType
     : BOOL
     | ERROR
+    | MATCH_KIND
     | BIT
     | INT
     | STRING

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -319,6 +319,7 @@ specializedType
 baseType
     : BOOL
     | ERROR
+    | MATCH_KIND
     | STRING
     | INT
     | BIT


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

See https://github.com/p4lang/p4c/pull/3099 for several P4 programs that cannot be compiled without this change. 