### PR TITLE
Fix #940 - Remove control plane API function signatures from PSA spec

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -57,7 +57,6 @@ interface ports.
 
 # Target Architecture Model
 
-
 As an analogy, the PSA is to the P4~16~ language as the C standard
 library is to the C programming language.  PSA defines a library of
 types, P4~16~ externs for frequently used constructs such as counters,
@@ -128,7 +127,7 @@ In this document we use the following naming conventions:
 
 - Types are named using CamelCase followed by `_t`. For example, `PortId_t`.
 - Control types and extern object types are named using CamelCase. For
-example `IngressParser`.
+  example `IngressParser`.
 - Struct types are named using lower case words separated by `_`
   followed by `_t`. For example `psa_ingress_input_metadata_t`.
 - Actions, extern methods, extern functions, headers, structs, and
@@ -311,9 +310,9 @@ from one PSA implementation to another[^PSAP4TargetSpecific].
     for different targets would be annotations on externs, etc. that
     the P4 compiler for that target needs to do its job.
 
-For each of these types, the P4 Runtime API[^P4RuntimeAPI] may use bit
-widths independent of the targets.  These widths are defined by the P4
-Runtime API specification, and they are expected to be at least as
+For each of these types, the P4Runtime API[^P4RuntimeAPI] may use bit
+widths independent of the targets.  These widths are defined by the
+P4Runtime API specification, and they are expected to be at least as
 large as the corresponding `InHeader_t` type below, such that they
 hold a value for any target.  All PSA implementations must use data
 plane sizes for these types no wider than the corresponding
@@ -413,11 +412,18 @@ determining which entry will win.
 
 ## Data plane vs. control plane data representations {#sec-data-plane-vs-control-plane-values}
 
-A PSA data plane implementation that supports the P4 Runtime
-API[^P4RuntimeAPI] includes software called a "P4 Runtime Server" that
-enables runtime programming of the PSA device from one or more "P4
-Runtime Clients".  For brevity, here we will call a P4 Runtime Server
-an "agent", and a P4 Runtime Client a "controller".  A controller may
+A PSA data plane may support multiple control plane APIs. Some of the
+notes in this section apply specifically to the case of the P4Runtime
+API[^P4RuntimeAPI] when used to control a PSA device. If you are using
+a different control plane API to control a PSA device, you should
+consult the documentation for that control plane API to learn exactly
+what API it provides to configure your PSA device.
+
+A PSA data plane implementation that supports the P4Runtime
+API[^P4RuntimeAPI] includes software called a "P4Runtime Server" that
+enables runtime programming of the PSA device from one or more
+"P4Runtime Clients".  For brevity, here we will call a P4Runtime Server
+an "agent", and a P4Runtime Client a "controller".  A controller may
 control multiple devices with different PSA implementations.
 
 As mentioned in section [#sec-psa-type-definitions], different PSA
@@ -435,7 +441,7 @@ table with a million entries[^CacheCost].
 
 [^CacheCost]: While 10 Mbits sounds tiny to one accustomed to computers with hundreds of gigabytes of DRAM, the highest speed PSA implementations are ASICs that must keep tables in on-chip memories, similar to caches in general purpose CPUs.  The Intel i9-7980XE released in 2017 has 198 Mbits of on-chip L3 cache shared by its CPU cores.  Among Intel processors in Intel's 7th generation Core released in 2017 with at least 100 Mbits of L3 cache, they all cost close to $9 per Mbit of L3 cache.  <https://en.wikipedia.org/wiki/List_of_Intel_microprocessors>
 
-The P4 Runtime API uses quantities with bit widths independent
+The P4Runtime API uses quantities with bit widths independent
 of the target device to hold values of the types
 listed in section [#sec-psa-type-definitions], to simplify the
 manipulation of these values in the controller and agent software.
@@ -686,7 +692,7 @@ The PSA does not put further restrictions on `packet_in.length()`
 as defined in the P4~16~ spec. Targets that do not support it, should provide mechanisms
 to raise an error.
 
-The P4 Runtime has a "Packet Out" capability to send a packet from the
+The P4Runtime has a "Packet Out" capability to send a packet from the
 controller to a PSA device.  Such packets are sent into the PSA device
 as NFCPU path packets.  There is no metadata associated with such
 packets, only the contents of the packet that are parsed normally by
@@ -888,7 +894,7 @@ queues for each class of service.  See appendix
 [#appendix-packet-ordering] for more on packet ordering
 recommendations in PSA devices.
 
-The P4 Runtime API specification defines how a controller may discover
+The P4Runtime API specification defines how a controller may discover
 the number of distinct class of service values that a PSA device
 supports.
 
@@ -978,7 +984,7 @@ egress processing.
 
 The `multicast_group` parameter is the multicast group id.  The
 control plane must configure the multicast groups through a separate
-mechanism such as the P4 Runtime API.
+mechanism such as the P4Runtime API.
 
 ```
 [INCLUDE=psa.p4:Action_multicast]
@@ -1252,7 +1258,7 @@ typical implementation will drop frames larger than this maximum
 supported size.  It is recommended that they maintain error counters
 for such dropped frames.
 
-The P4 Runtime has a "Packet In" capability to receive packets sent by
+The P4Runtime has a "Packet In" capability to receive packets sent by
 a PSA device to the port `PSA_PORT_CPU`.  There is no metadata
 associated with such packets, only the contents of the packet that are
 emitted normally by the P4 program's EgressDeparser code.  There may
@@ -1953,7 +1959,7 @@ conditions under which one of these three results is returned.  The P4
 program is responsible for examining that returned result, and making
 changes to packet forwarding behavior as a result.
 The value returned by an uninitialized meter shall be GREEN. This is in
-accordance with the P4 Runtime specification.
+accordance with the P4Runtime specification.
 
 
 RFC 2698 describes "color aware" and "color blind" variations of
@@ -1965,7 +1971,7 @@ Similar to counters, there are two flavors of meters: indexed and
 direct.  (Indexed) meters are addressed by index, while direct meters
 always update a meter state corresponding to the matched table entry
 or action, and from the control plane API are addressed using
-P4 Runtime table entry as key.
+P4Runtime table entry as key.
 
 There are many other similarities between counters and meters,
 including:
@@ -2403,10 +2409,10 @@ control Ctrl(inout H hdr, inout M meta) {
 
 Note that the management of action selector entries in the presence of
 link failures is outside the scope of the PSA. Fast-failover requires
-information from the control plane and will be addressed as part of the P4
-Runtime API[^P4RuntimeAPI] working group.
+information from the control plane and will be addressed as part of the
+P4Runtime API[^P4RuntimeAPI] working group.
 
-[^P4RuntimeAPI]: The P4 Runtime API is defined as a Google Protocol
+[^P4RuntimeAPI]: The P4Runtime API is defined as a Google Protocol
     Buffer `.proto` file and an accompanying English specification document
     here:
     <https://github.com/p4lang/p4runtime>
@@ -2494,7 +2500,7 @@ synchronization, e.g. via PTP[^PTP] or NTP[^NTP].
 [^NTP]: <https://en.wikipedia.org/wiki/Network_Time_Protocol>
 
 The control plane API excerpt below is intended to be added as part of
-the P4 Runtime API.
+the P4Runtime API.
 
 ```
 // The TimestampInfo and Timestamp messages should be added to the
@@ -2594,7 +2600,7 @@ instance.  The argument is the value to be included in the digest,
 often a collection of values in a P4 `struct` type.  The compiler
 decides the best serialization format to send the digest contents to a
 local software agent, which is responsible for sending the digest data
-in a form defined by the P4 Runtime API specification.
+in a form defined by the P4Runtime API specification.
 
 A PSA program can instantiate multiple Digest instances in the same
 IngressDeparser control block, and make at most one `pack` call on
@@ -2677,7 +2683,7 @@ Every packet doing an `apply` on table `T` and matching the entry with
 key `K` should execute action `A` with either the old 100 bits of
 action parameters, or the new 100 bits of action parameters.
 
-The P4 Runtime API enables controllers to create "batch" messages that perform
+The P4Runtime API enables controllers to create "batch" messages that perform
 more than one single operation, as defined here.  If so, a PSA
 implementation need only ensure that each single operation is atomic.
 There is no requirement that a sequence of _multiple_ table entry add,
@@ -2704,7 +2710,7 @@ plane to atomically read, modify, then write back a Register array
 element, you should write your P4 program such that the desired read,
 modify, and write operation can be done by a packet that your control
 plane can inject into the data plane, e.g. via packet in / packet out
-P4 Runtime API operations.
+P4Runtime API operations.
 
 A high speed PSA implementation might process hundreds or thousands of
 packets between each single control plane operation.  There are common
@@ -3606,6 +3612,21 @@ how the control plane plans to configure the matching rules of a
 table, and (b) the additional restrictions it has over match kind
 `ternary` provides opportunities for target devices to implement it
 more efficiently than `ternary`.
+
+
+### Remove control plane API function signatures
+
+As a historical note, the control plane API function signatures that
+were formerly given in comments preceded by the string
+`@ControlPlaneAPI` were added very early in the process of writing
+version 1.0 of the PSA specification, and were never reviewed
+thoroughly.  The P4Runtime API specification version 1.0 was being
+developed at the same time as version 1.0 of the PSA specification.
+They were removed because we believe that no one ever implemented
+precisely those APIs for any P4-programmable device (although similar
+APIs have been implemented), and their presence was confusing those
+new to the PSA specification, who believed that those function
+signatures were required to be implemented.
 
 
 ## Changes made in version 1.1

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -536,28 +536,6 @@ enum PSA_CounterType_t {
 extern Counter<W, S> {
   Counter(bit<32> n_counters, PSA_CounterType_t type);
   void count(in S index);
-
-  /*
-  /// The control plane API uses 64-bit wide counter values.  It is
-  /// not intended to represent the size of counters as they are
-  /// stored in the data plane.  It is expected that control plane
-  /// software will periodically read the data plane counter values,
-  /// and accumulate them into larger counters that are large enough
-  /// to avoid reaching their maximum values for a suitably long
-  /// operational time.  A 64-bit byte counter increased at maximum
-  /// line rate for a 100 gigabit port would take over 46 years to
-  /// wrap.
-
-  @ControlPlaneAPI
-  {
-    bit<64> read      (in S index);
-    bit<64> sync_read (in S index);
-    void set          (in S index, in bit<64> seed);
-    void reset        (in S index);
-    void start        (in S index);
-    void stop         (in S index);
-  }
-  */
 }
 // END:Counter_extern
 
@@ -565,18 +543,6 @@ extern Counter<W, S> {
 extern DirectCounter<W> {
   DirectCounter(PSA_CounterType_t type);
   void count();
-
-  /*
-  @ControlPlaneAPI
-  {
-    W    read<W>      (in TableEntry key);
-    W    sync_read<W> (in TableEntry key);
-    void set          (in TableEntry key, in W seed);
-    void reset        (in TableEntry key);
-    void start        (in TableEntry key);
-    void stop         (in TableEntry key);
-  }
-  */
 }
 // END:DirectCounter_extern
 
@@ -606,15 +572,6 @@ extern Meter<S> {
   // RFC 2698).  It may be implemented via a call to execute(index,
   // MeterColor_t.GREEN), which has the same behavior.
   PSA_MeterColor_t execute(in S index);
-
-  /*
-  @ControlPlaneAPI
-  {
-    reset(in MeterColor_t color);
-    setParams(in S index, in MeterConfig config);
-    getParams(in S index, out MeterConfig config);
-  }
-  */
 }
 // END:Meter_extern
 
@@ -624,15 +581,6 @@ extern DirectMeter {
   // See the corresponding methods for extern Meter.
   PSA_MeterColor_t execute(in PSA_MeterColor_t color);
   PSA_MeterColor_t execute();
-
-  /*
-  @ControlPlaneAPI
-  {
-    reset(in TableEntry entry, in MeterColor_t color);
-    void setConfig(in TableEntry entry, in MeterConfig config);
-    void getConfig(in TableEntry entry, out MeterConfig config);
-  }
-  */
 }
 // END:DirectMeter_extern
 
@@ -648,15 +596,6 @@ extern Register<T, S> {
   @noSideEffects
   T    read  (in S index);
   void write (in S index, in T value);
-
-  /*
-  @ControlPlaneAPI
-  {
-    T    read<T>      (in S index);
-    void set          (in S index, in T seed);
-    void reset        (in S index);
-  }
-  */
 }
 // END:Register_extern
 
@@ -670,14 +609,6 @@ extern Random<T> {
 
   Random(T min, T max);
   T read();
-
-  /*
-  @ControlPlaneAPI
-  {
-    void reset();
-    void setSeed(in T seed);
-  }
-  */
 }
 // END:Random_extern
 
@@ -685,15 +616,6 @@ extern Random<T> {
 extern ActionProfile {
   /// Construct an action profile of 'size' entries
   ActionProfile(bit<32> size);
-
-  /*
-  @ControlPlaneAPI
-  {
-     entry_handle add_member    (action_ref, action_data);
-     void         delete_member (entry_handle);
-     entry_handle modify_member (entry_handle, action_ref, action_data);
-  }
-  */
 }
 // END:ActionProfile_extern
 
@@ -704,19 +626,6 @@ extern ActionSelector {
   /// @param size number of entries in the action selector
   /// @param outputWidth size of the key
   ActionSelector(PSA_HashAlgorithm_t algo, bit<32> size, bit<32> outputWidth);
-
-  /*
-  @ControlPlaneAPI
-  {
-     entry_handle add_member        (action_ref, action_data);
-     void         delete_member     (entry_handle);
-     entry_handle modify_member     (entry_handle, action_ref, action_data);
-     group_handle create_group      ();
-     void         delete_group      (group_handle);
-     void         add_to_group      (group_handle, entry_handle);
-     void         delete_from_group (group_handle, entry_handle);
-  }
-  */
 }
 // END:ActionSelector_extern
 
@@ -724,14 +633,6 @@ extern ActionSelector {
 extern Digest<T> {
   Digest();                       /// define a digest stream to the control plane
   void pack(in T data);           /// emit data into the stream
-
-  /*
-  @ControlPlaneAPI
-  {
-  T data;                           /// If T is a list, control plane generates a struct.
-  int unpack(T& data);              /// unpacked data is in T&, int return status code.
-  }
-  */
 }
 // END:Digest_extern
 


### PR DESCRIPTION
Rationale for this was added in change log section.