### PR TITLE
One cannot have variables with type int

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4969,8 +4969,9 @@ same way as described for direction `out` parameters in Section
 [#sec-calling-convention]). The language places few restrictions on
 the types of the variables: most P4 types that can be written
 explicitly can be used (e.g., base types, `struct`, `header`,
-header stack, `tuple`). However, it is impossible to declare variables with types
-that are only synthesized by the compiler (e.g., `set`). In addition, variables of type  `parser`, `control`, `package`,
+header stack, `tuple`). However, it is impossible to declare variables with type `int`,
+or with types that are only synthesized by the compiler (e.g., `set`)
+In addition, variables of type  `parser`, `control`, `package`,
 or `extern` types must be declared using instantiations (see Section [#sec-instantiations]).
 
 Reading the value of a variable that has not been initialized yields


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

Fixes #1037