### PR TITLE
Forbid applying tables within action parameters in a table definition

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6569,10 +6569,9 @@ Each action parameter that has a direction (`in`, `inout`, or `out`)
 must be bound in the `actions` list specification; conversely, no
 directionless parameters may be bound in the list. The expressions
 supplied as arguments to an `action` are not evaluated until the
-action is invoked.
-Applying tables, whether directly via an expression like
-`table1.apply().hit ? expr1 : expr2`, or indirectly, are forbidden in
-the expressions supplied as action arguments.
+action is invoked. Applying tables, whether directly via an expression
+like `table1.apply().hit`, or indirectly, are forbidden in the
+expressions supplied as action arguments.
 
 ~ Begin P4Example
 action a(in bit<32> x) { /* body omitted */ }

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6570,6 +6570,9 @@ must be bound in the `actions` list specification; conversely, no
 directionless parameters may be bound in the list. The expressions
 supplied as arguments to an `action` are not evaluated until the
 action is invoked.
+Applying tables, whether directly via an expression like
+`table1.apply().hit ? expr1 : expr2`, or indirectly, are forbidden in
+the expressions supplied as action arguments.
 
 ~ Begin P4Example
 action a(in bit<32> x) { /* body omitted */ }
@@ -6582,6 +6585,7 @@ table t {
        b(z);  // binding b's parameter x to z
        // b(z, 3); -- illegal, cannot bind directionless data parameter
        // b(); -- illegal, x parameter must be bound
+       // a(table2.apply().hit ? 5 : 3); -- illegal, cannot apply a table here
     }
 }
 ~ End P4Example


### PR DESCRIPTION
Intended as an alternative to p4-spec PR #852.