### PR TITLE
Correct example that uses LearningProvider extern object

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3884,10 +3884,12 @@ For example, the following program fragment uses a list expression to
 pass several header fields simultaneously to a learning provider:
 
 ~ Begin P4Example
-extern LearningProvider {
-    void learn<T>(in T data);
+extern LearningProvider<T> {
+    LearningProvider();
+    void learn(in T data);
 }
-LearningProvider() lp;
+
+LearningProvider<tuple<bit<48>, bit<32>>>() lp;
 
 lp.learn( { hdr.ethernet.srcAddr, hdr.ipv4.src } );
 ~ End P4Example


### PR DESCRIPTION
Thanks to Cristian Dumitrescu for pointing out that this example code did not look legal.

There are multiple options for making it legal P4_16 code.  This is just one way, which I have verified passes with a recent version of p4test.