### PR TITLE
Add string type to "Type nesting rules" table

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2545,6 +2545,7 @@ infinite-precision integer, without a width specified.
 | `varbit<W>`    | allowed   | error   |  allowed |
 | `int`          | error     | error   |  error   |
 | `void`         | error     | error   |  error   |
+| `string`       | error     | error   |  error   |
 | `error`        | error     | error   |  allowed |
 | `match_kind`   | error     | error   |  error   |
 | `bool`         | allowed   | error   |  allowed |


### PR DESCRIPTION
I noticed string was missing from the type nesting rules
table and this adds it.

Signed-off-by: Andrew Pinski <apinski@marvell.com>