### PR TITLE
Clearify structured-value expressions and their fields

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3962,7 +3962,10 @@ arguments to functions, method or actions.  Structure-valued
 expressions are not left values.
 
 The compiler must raise an error if a field name appears more than
-once in the same structure-valued expression.
+once in the same structure-valued expression. The order of the fields
+of the `struct` or `header` type does not need to match the order of
+the values of the structure-valued expression. All of the fields of
+the `struct` or `header` types do need to be initialized though.
 
 ## Operations on sets { #sec-set-exprs }
 


### PR DESCRIPTION
This clearifies a few things
* the order of the initialization does not matter
* All of the fields of the struct/header types need be initialized

These might seem implicit but when writing a specifications like this,
they should be explicit.

Signed-off-by: Andrew Pinski <apinski@marvell.com>