### PR TITLE
psa: Fix typo

### DIFF
--- a/p4-16/psa/PSA.mdk
+++ b/p4-16/psa/PSA.mdk
@@ -2086,7 +2086,7 @@ seen for a particular type of flow.  A register cell would be
 allocated to the flow, initialized to "clear".  When the protocol
 signaled a "first packet", the table would match on this value and
 update the flow's cell to "marked".  Subsequent packets in the flow
-could would be mapped to the same cell; the current cell value would
+would be mapped to the same cell; the current cell value would
 be stored in metadata for the packet and a subsequent table could
 check that the flow was marked as active.
 


### PR DESCRIPTION
This pull request removes the word `could` in the following sentence:

```
Subsequent packets in the flow could would be mapped to the same cell;
```