### PR TITLE
Allow direct invocation of generic controls/parsers 

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1882,19 +1882,16 @@ The `match_kind` type is very similar to the `error` type and
 is used to declare a set of names that may be
 used in a table's key property (described in Section
 [#sec-table-props]).
+All identifiers are inserted into the
+top-level namespace.
+It is an error to declare the same `match_kind`
+identifier multiple times.
 
 ~ Begin P4Grammar
 matchKindDeclaration
     : MATCH_KIND '{' identifierList '}'
     ;
 ~ End P4Grammar
-
-All `match_kind` constants are inserted into the `match_kind`
-namespace. `match_kind` is similar to an enumeration (`enum`)
-type in other languages. A program can contain multiple `match_kind` declarations, which
-the compiler will merge together. It is an error to declare the same
-identifier multiple times. Expressions of type `match_kind` are
-described in Section [#sec-match_kind-exprs].
 
 The P4 core library contains the following match_kind declaration:
 
@@ -3148,16 +3145,6 @@ side-effects. P4 expressions are evaluated as follows:
   the source program.
 - Method and function calls are evaluated as described in Section
   [#sec-calling-convention].
-
-## Expressions on `match_kind` value { #sec-match_kind-exprs }
-
-Symbolic names declared by an `match_kind` declaration belong to the `match_kind`
-namespace.  The `match_kind` type only supports equality (`==`) and inequality (`!=`) comparisons.
-The result of such a comparison is a Boolean value.
-
-As an exception to the standard name lookup rules of P4,
-constants of type `match_kind` can be used without the `match_kind.` prefix
-when used in a table key field (see Section [#sec-table-keys]).
 
 ## Operations on `error` types { #sec-error-exprs }
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -7087,7 +7087,7 @@ control Callee(/* parameters omitted */) { /* body omitted */ }
 
 control Caller(/* parameters omitted */)(/* parameters omitted */) {
     apply {
-        Callee.apply(/* arguments omitted */); // callee is treated as an instance
+        Callee.apply(/* arguments omitted */); // Callee is treated as an instance
     }
 }
 ~ End P4Example
@@ -7110,9 +7110,24 @@ directApplication
     ;
 ~ End P4Grammar
 
-This feature is intended to streamline the common case where a type is instantiated
-exactly once.  For completeness, the behavior of directly invoking the
-same type more than once is defined as follows.
+This feature is intended to streamline the common case where a type is
+instantiated exactly once.
+
+The second production in the grammar allows direct calls for generic
+controls or parsers:
+
+~ Begin P4Example
+control Callee<T>(/* parameters omitted */) { /* body omitted */ }
+
+control Caller(/* parameters omitted */)(/* parameters omitted */) {
+    apply {
+        Callee<bit<32>>.apply(/* arguments omitted */); // Callee<bit<32>> is treated as an instance
+    }
+}
+~ End P4Example
+
+For completeness, the behavior of directly invoking the same type more
+than once is defined as follows.
 
 - Direct type invocation in different scopes will result in different
   local instances with different fully-qualified control names.

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1882,16 +1882,19 @@ The `match_kind` type is very similar to the `error` type and
 is used to declare a set of names that may be
 used in a table's key property (described in Section
 [#sec-table-props]).
-All identifiers are inserted into the
-top-level namespace.
-It is an error to declare the same `match_kind`
-identifier multiple times.
 
 ~ Begin P4Grammar
 matchKindDeclaration
     : MATCH_KIND '{' identifierList '}'
     ;
 ~ End P4Grammar
+
+All `match_kind` constants are inserted into the `match_kind`
+namespace. `match_kind` is similar to an enumeration (`enum`)
+type in other languages. A program can contain multiple `match_kind` declarations, which
+the compiler will merge together. It is an error to declare the same
+identifier multiple times. Expressions of type `match_kind` are
+described in Section [#sec-match_kind-exprs].
 
 The P4 core library contains the following match_kind declaration:
 
@@ -3145,6 +3148,16 @@ side-effects. P4 expressions are evaluated as follows:
   the source program.
 - Method and function calls are evaluated as described in Section
   [#sec-calling-convention].
+
+## Expressions on `match_kind` value { #sec-match_kind-exprs }
+
+Symbolic names declared by an `match_kind` declaration belong to the `match_kind`
+namespace.  The `match_kind` type only supports equality (`==`) and inequality (`!=`) comparisons.
+The result of such a comparison is a Boolean value.
+
+As an exception to the standard name lookup rules of P4,
+constants of type `match_kind` can be used without the `match_kind.` prefix
+when used in a table key field (see Section [#sec-table-keys]).
 
 ## Operations on `error` types { #sec-error-exprs }
 
@@ -6444,7 +6457,7 @@ constant, so the `const` keyword is not needed for these.
 
 ### Table properties { #sec-table-props }
 
-#### Keys
+#### Keys { #sec-table-keys }
 
 The `key` is a table property which specifies the data plane
 values that should be used to look up an entry. A key is a list of
@@ -7102,6 +7115,13 @@ control Caller(/* parameters omitted */)(/* parameters omitted */) {
     }
 }
 ~ End P4Example
+
+~ Begin P4Grammar
+directApplication
+    : typeName "." APPLY "(" argumentList ")" ";"
+    | specializedType "." APPLY "(" argumentList ")" ";"
+    ;
+~ End P4Grammar
 
 This feature is intended to streamline the common case where a type is instantiated
 exactly once.  For completeness, the behavior of directly invoking the

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -474,6 +474,7 @@ conditionalStatement
 // To support direct invocation of a control or parser without instantiation
 directApplication
     : typeName '.' APPLY '(' argumentList ')' ';'
+    | specializedType '.' APPLY '(' argumentList ')' ';'
     ;
 
 statement


### PR DESCRIPTION
I could argue that this is a bug, but perhaps it should be discussed in the design working group.