### PR TITLE
Do not allow typedef with unspecialized generic types

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2986,6 +2986,18 @@ The two types are treated as synonyms, and all operations that can be
 executed using the original type can be also executed using the newly
 created type.
 
+If `typedef` is used with a generic type the type must be specialized
+with the suitable number of type arguments:
+
+~ Begin P4Example
+struct S<T> {
+   T field;
+}
+
+// typedef S X;  -- illegal: S does not have type arguments
+typedef S<bit<32>> X;  // -- legal
+~ End P4Example
+
 ## Introducing new types { #sec-newtype }
 
 Similarly to `typedef`, the keyword `type` can be used to introduce a


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>

Fixes #1045 
Already fixed in the compiler by https://github.com/p4lang/p4c/pull/3174