### PR TITLE
Fix small typo in example in sec-implicit-casts section

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3799,7 +3799,7 @@ For example, given the following declarations,
 
 ~ Begin P4Example
 enum bit<8> E {
-   a = 5;
+   a = 5
 }
 
 bit<8>  x;


### PR DESCRIPTION
The ';' is wrong inside the enum and should be removed. Inside enums, ','
is the seperator but since there is only one value, it can be removed.

Signed-off-by: Andrew Pinski <apinski@marvell.com>