### PR TITLE
mask (`&&&`) and range (`..`) operators have the wrong precedence

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4053,7 +4053,7 @@ simpleKeysetExpression
 ~ End P4Grammar
 
 The mask (`&&&`) and range (`..`) operators have the same
-precedence, which is just higher than `&`.
+precedence; the just above the `?:` operator.
 
 ### Singleton sets { #sec-singleton-set }
 


### PR DESCRIPTION
These two operators actually have the highest precedence
even higher than just `&` (just above the `?:` operator)
in both the grammer in the specifications and even in the reference compiler.

Signed-off-by: Andrew Pinski <apinski@marvell.com>