### PR TITLE
Clarify semantics for table entries without key

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6725,7 +6725,8 @@ enables expressing these algorithm directly in P4,
 which allows the compiler to infer how the table is actually used and
 potentially make better allocation decisions for targets with limited
 resources. Entries declared in the P4 source are installed in the
-table when the program is loaded onto the target.
+table when the program is loaded onto the target. Entries cannot be
+specified for a table with no key (see Sec. [#sec-table-keys]).
 
 Table entries are defined using the following syntax:
 


### PR DESCRIPTION
This pull request clarifies that table entries cannot be specified for a table with no `key` property (or when the value of its `key` is empty list).