### PR TITLE
Fix tuple-type reference.

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3910,7 +3910,7 @@ expressionList
 ~ End P4Grammar
 
 The type of a list expression is a tuple type (Section
-[#sec-synth-types]). List expressions can be assigned to expressions
+[#sec-tuple-types]). List expressions can be assigned to expressions
 of type `tuple`, `struct` or `header`, and can also be
 passed as arguments to methods. Lists may be nested. However, list
 expressions are not l-values.


### PR DESCRIPTION
In the "Operations on lists" section, the reference for tuple types points to a section that does not cover tuple types. This small change updates the reference to point to the tuple types section.