### PR TITLE
Add sentence about table's keys and implementation limitations

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6592,6 +6592,10 @@ table is always the empty map.
 Each key element can have an optional `@name` annotation which is
 used to synthesize the control-plane-visible name for the key field.
 
+Note some implementations might only support a limited number of keys or
+a limited combinations of match_kind for the keys. The implementation
+should reject those cases with an error message in this case.
+
 #### Actions { #sec-table-action-list }
 
 A table must declare all possible actions that may appear within the


### PR DESCRIPTION
This should be non-controversial as it documents what is
already the behavior of implementations of today.
Adding this sentence just clarifies the section
and if it is ok for an implementation not to implement
an infinite key size or a combination of match_kinds.

Signed-off-by: Andrew Pinski <apinski@marvell.com>