### PR TITLE
push_front and pop_front should only be usable from parser

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4316,14 +4316,14 @@ manipulate the elements at the front and back of the stack:
   elements in the stack are discarded. The `hs.nextIndex` counter
   is incremented by `count`. The `count` argument must be a
   positive integer that is a compile-time known value. The return type
-  is `void`.
+  is `void`. May only be used in a `parser`.
 
 - `hs.pop_front(int count)`: shifts `hs` "left" by `count`
   (i.e., element with index `count` is copied in stack at index `0`).
   The last `count` elements become invalid. The `hs.nextIndex`
   counter is decremented by `count`. The `count` argument must
   be a positive integer that is a compile-time known value. The return
-  type is `void`.
+  type is `void`. May only be used in a `parser`.
 
 The following pseudocode defines the behavior of `push_front` and `pop_front`:
 


### PR DESCRIPTION
Just like how next, last and lastIndex are usable from parsers only, push_front and pop_front should only be usable from parsers.

Signed-off-by: Andrew Pinski <apinski@marvell.com>