### PR TITLE
Clarified implicit casts in select expressions

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3834,6 +3834,14 @@ the compiler will add implicit casts as follows:
 - `x[E.a:0]` becomes `x[(bit<8>)E.a:0]`
 - `E.a ++ 8w0` becomes `(bit<8>)E.a ++ 8w0`
 
+The compiler also adds implicit casts when types of different
+expressions need to ``match''; for example, as described in Section
+[#sec-select], since select labels are compared againt the selected
+expression, the compiler will insert implicit casts for the select
+labels when they have `int` types.  Similarly, when assigning a
+structure-valued expression to a structure or header, the compiler will
+add implicit casts for `int` fields.
+
 ### Illegal arithmetic expressions { #sec-illegal-arith }
 
 Many arithmetic expressions that would be allowed in other languages

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5756,7 +5756,10 @@ selectCase
 ~ End P4Grammar
 
 In a `select` expression, if the `expressionList` has type `tuple<T>`,
-then each `keysetExpression` must have type `set<tuple<T>>`.
+then each `keysetExpression` must have type `set<tuple<T>>`.  In
+particular, if a set is specified as a range or mask expression, the
+endpoints of the range and mask expression are implicitly cast to type
+`T` using the standard rules for casts.
 
 In terms of the `ParserModel`, the meaning of a select expression:
 
@@ -8347,6 +8350,7 @@ The P4 compiler should provide:
 
 ## Summary of changes made in version 1.2.4
 
+* Clarified implicit casts present in select expressions ([#sec-select]).
 * Clarified that no direct invocation is possible for objects that have constructor arguments ([#sec-direct-type-invocation]).
 * Clarified semantics of ranges where the start is bigger than the end (Section [#sec-ranges]).
 * Allow ranges to be specified by serializable enums (Section [#sec-ranges]).


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #1106