### PR TITLE
p4-16-spec: fix typo

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3892,7 +3892,7 @@ cannot guess the user intent, so P4 requires the user to disambiguate.
 |                         |                           |  `(bit<8>)y + (bit<8>)z ` |
 |                         |                           |  `(int<16>)y + (int<16>)z ` |
 | `x << z`            | RHS of shift cannot be signed |  `x << (bit<8>)z ` |
-| `x < z`             | Different signs |  `X < (bit<8>)z ` |
+| `x < z`             | Different signs |  `x < (bit<8>)z ` |
 |                         |                           |  `(int<8>)x < z ` |
 | `1 << x`            | Either LHS should have a fixed width (bit shift),  |  `32w1 << x ` |
 |                     | Or RHS must be compile-time known (int shift) |  None |


### PR DESCRIPTION
This pull request fixes a typo where upper-case `X` has been used instead of lower-case `x` in alternative example of illegal arithmetic expression.