### PR TITLE
Reference C++11/C23 attributes rather than Java or C#

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -7986,13 +7986,13 @@ error.
 
 # Annotations { #sec-annotations }
 
-Annotations are similar to C# attributes and Java annotations. They are a simple
-mechanism for extending the P4 language to some limited degree without changing
-the grammar. To some degree they subsume C `#pragma`s. Annotations are attached
-to types, fields, variables, etc. using the `@` syntax (as shown explicitly in
-the P4 grammar). Unstructured annotations, or just "annotations," have an
-optional body; structured annotations have a mandatory body, containing at least
-a pair of square brackets `[]`.
+Annotations are a simple mechanism for extending the P4 language to
+some limited degree without changing the grammar. Annotations are
+attached to types, fields, variables, etc. using the `@` syntax
+(as shown explicitly in the P4 grammar). Unstructured annotations,
+or just "annotations," have an optional body; structured annotations
+have a mandatory body, containing at least a pair of square brackets
+`[]`.
 
 ~ Begin P4Grammar
 optAnnotations


### PR DESCRIPTION
Since more people will more likely know about C++11 attributes than C# or Java, make reference to that instead.
C23 adds the same kind of attributes as C++11 had added so reference C23 too.
C# and Java are less likely to be known to many developers.
Remove reference to C's `#pragma`s since C++11/C23 attributes are more similar and `#pragma` are less likely to be used now.

Signed-off-by: Andrew Pinski <apinski@marvell.com>