### PR TITLE
Fix spelling of an incorrect cross-reference

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -8440,7 +8440,7 @@ The P4 compiler should provide:
 ## Summary of changes made in version 1.2.4
 
 * Clarified implicit casts present in select expressions (Section [#sec-select]).
-* Clarified that slices can be applied to arbitary-precision integers (Section [#sec-varint-rrops]).
+* Clarified that slices can be applied to arbitary-precision integers (Section [#sec-varint-ops]).
 * Clarified the behavior of `lookahead` on header-typed values (Section [#sec-packet-lookahead]).
 * Clarified that no direct invocation is possible for objects that have constructor arguments ([#sec-direct-type-invocation]).
 * Added `static_assert` function (Section [#sec-static-assert]).


### PR DESCRIPTION
I happened to notice this while trying to build HTML and PDF of the latest spec.