### PR TITLE
Add a note about duplicated table properties

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -6520,7 +6520,8 @@ necessary to disambiguate.
 Syntactically a table is defined in terms of a set of key-value
 properties. Some of these properties are "standard" properties, but
 the set of properties can be extended by target-specific compilers as
-needed.
+needed. Note duplicated properties are invalid and the compiler should
+reject them.
 
 ~ Begin P4Grammar
 tableDeclaration


### PR DESCRIPTION
Even though the spec says table properties is
implemented as key-value pair, it could have been
the case where the last pair would have won.
This makes it explict that the if there is a
duplicated property, then the compiler should
reject it.

Fixes #1162

Signed-off-by: Andrew Pinski <apinski@marvell.com>