### PR TITLE
Specify that comparison is legal for tuples

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3935,6 +3935,9 @@ The fields of a tuple can be accessed using array index syntax `x[0]`,
 `x[1]`.  The array indexes *must* be compile-time constants, to enable
 the type-checker to identify the field types statically.
 
+Tuples can be compared for equality using `==` and `!=`; two tuples are
+equal if and only if all their fields are respectively equal.
+
 Currently tuple fields are not left-values, even if the tuple itself
 is.  (I.e. a tuple can only be assigned monolithically, and the field
 values cannot be changed individually.)  This restriction may be
@@ -8439,6 +8442,7 @@ The P4 compiler should provide:
 
 ## Summary of changes made in version 1.2.4
 
+* Added comparison for tuples as a legal operation (Section [#sec-tuple-exprs]).
 * Explicitly disallow overloading of parsers, controls, and packages (Section [#sec-extern-objects]).
 * Clarified implicit casts present in select expressions (Section [#sec-select]).
 * Clarified that slices can be applied to arbitary-precision integers (Section [#sec-varint-ops]).


### PR DESCRIPTION
Signed-off-by: Mihai Budiu <mbudiu@vmware.com>
Fixes #1094