### PR TITLE
Fix casting

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3689,9 +3689,11 @@ The following casts are legal in P4:
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
-- casts between a typedef and the original type.
-- casts between a type introduced by `type` and the original type.
-- casts between an `enum` with an explicit type and its underlying type
+- casts from a typedef to the original type and vice versa.
+- casts from a type introduced by `type` to the original type and vice versa.
+- casts from an `enum` with an explicit type to its underlying type and vice versa.
+- casts between two `enum` with the same underlying type.
+
 
 ### Implicit casts { sec-implicit-casts }
 
@@ -3753,6 +3755,7 @@ several ways that the expression could be manually rewritten into a
 legal expression. Note that for some expression there are several
 legal alternatives, which may produce different results! The compiler
 cannot guess the user intent, so P4 requires the user to disambiguate.
+Thus, it cannot insert implicit casts to make the expression legal.
 
 |-----|-----|-----|
 | Expression | Why it is illegal  | Alternatives |

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3135,7 +3135,8 @@ implicit casting from an `enum` to its fixed-width (signed or unsigned) integer 
 bit<8> x = E.e2; // sets x to 1 (E.e2 is implicitly casted to bit<8>)
 
 E  a = E.e2
-bit<8> y = a << 3; // sets y to 8 (a is implicitly casted to bit<8> and then shifted)
+bit<8> y = a << 3; // sets y to 8
+                   //(a is implicitly casted to bit<8> and then shifted)
 ~ End P4Example
 
 Implicit casting from an underlying fixed-width type to an enum is *not* supported.
@@ -3920,7 +3921,7 @@ struct S {
 
 extern void f<T>(in T data);
 
-f((S){ 10, 20 }); // automatically converted to f((S){a = 10, b = 20});
+f((S){ 10, 20 }); // implicit cast of tuple to f((S){a = 10, b = 20});
 ~ End P4Example
 
 Tuple expressions can also be used to initialize variables whose type

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2936,7 +2936,7 @@ This declaration will prevent `PortId_t` values from being used in
 arithmetic expressions without casts.  Moreover, this declaration may enable special
 manipulation or such values by software that lies outside of the
 datapath (e.g., a target-specific toolchain could include software
-that automatically converts values of type `PortId_t` to a different
+that implicitly casts type `PortId_t` to a different
 representation when exchanged with the control-plane software).
 
 # Expressions { #sec-exprs }
@@ -3110,10 +3110,10 @@ Because it is always safe to cast from an `enum` to its underlying fixed-width i
 implicit casting from an `enum` to its fixed-width (signed or unsigned) integer type is also supported (see Section [#sec-implicit-casts]):
 
 ~ Begin P4Example
-bit<8> x = E.e2; // sets x to 1 (E.e2 is automatically casted to bit<8>)
+bit<8> x = E.e2; // sets x to 1 (E.e2 is implicitly casted to bit<8>)
 
 E  a = E.e2
-bit<8> y = a << 3; // sets y to 8 (a is automatically casted to bit<8> and then shifted)
+bit<8> y = a << 3; // sets y to 8 (a is implicitly casted to bit<8> and then shifted)
 ~ End P4Example
 
 Implicit casting from an underlying fixed-width type to an enum is *not* supported.
@@ -3129,32 +3129,32 @@ enum bit<8> E2 {
 E1 a = E1.e1;
 E2 b = E2.e2;
 
-a = b;      // Error: b is automatically casted to bit<8>,
-            // but bit<8> cannot be automatically casted to E1
+a = b;      // Error: b is implicitly casted to bit<8>,
+            // but bit<8> cannot be implicitly casted to E1
 
 a = (E1) b; // OK
 
-a = E1.e1 + 1; // Error: E.e1 is automatically casted to bit<8>,
+a = E1.e1 + 1; // Error: E.e1 is implicitly casted to bit<8>,
                // and the right-hand expression has
-               // the type bit<8>, which cannot be casted to E automatically.
+               // the type bit<8>, which cannot be casted to E implicitly.
 
 a = (E1)(E1.e1 + 1); // Final explicit casting makes the assignment legal
 
-a = E1.e1 + E1.e2; // Error: both arguments to the addition are automatically
+a = E1.e1 + E1.e2; // Error: both arguments to the addition are implicitly
                    // casted to bit<8>. Thus the addition itself is legal, but
                    // the assignment is not
 
 a = (E1)(E2.e1 + E2.e2); //  Final explicit casting makes the assignment legal
 ~ End P4Example
 
-A reasonable compiler might generate a warning in cases that involve multiple automatic casts.
+A reasonable compiler might generate a warning in cases that involve multiple implicit casts.
 
 ~ Begin P4Example
 E1     a = E1.e1;
 E2     b = E2.e2;
 bit<8> c;
 
-if (a > b) { // Potential warning: two automatic and different casts to bit<8>.
+if (a > b) { // Potential warning: two implicit and different casts to bit<8>.
    // code omitted
 }
 
@@ -3555,7 +3555,7 @@ expressions of type `int` must be compile-time known values.  The type
 Each operand that participates in any of these operation must have
 type `int` (except shifts). Binary operations cannot
 be used to combine values of type `int` with values of a fixed-width
-type (except shifts). However, the compiler automatically inserts casts from `int`
+type (except shifts). However, the compiler implicitly casts type `int`
 to fixed-width types in certain situations---see Section [#sec-casts].
 
 All computations on `int` values are carried out without loss of
@@ -3658,9 +3658,24 @@ finding this information in a section dedicated to type `varbit`.
 
 ## Casts { #sec-casts }
 
-P4 provides a limited set of casts between types. A cast is written
-`(t) e`, where `t` is a type and `e` is an expression. Casts are only
-permitted on base types and derived types introduced by `typedef`, `type`, and `enum`.
+P4 provides a limited set of casts between types. The syntax of a cast is given by:
+
+~ Begin P4Grammar
+expression ...
+    | '(' typeRef ')' expression
+    | '(' name ')' expression
+    ;
+
+~ End P4Grammar
+
+In essense, a cast is written
+`(t) e`, where `t` is a type or a name associated to a type and `e` is an expression. 
+More specifically, `t` can be
+
+- a base type or a `tuple` type
+- a name that represents an `enum`, `struct`, `header`
+- a name representing a derived type introduced by `typedef` or `type`
+
 While this design is arguably more onerous for programmers, it has several benefits:
 
 - It makes user intent unambiguous.
@@ -3865,10 +3880,14 @@ struct S {
     bit<32> b;
 }
 const S x = { 10, 20 }; //a = 10, b = 20
+                        // implicit cast of type tuple to struct
 ~ End P4Example
 
-A tuple expression can have an explicit structure or header type
-specified, and then it is converted automatically to a
+TODO!! is cast tuple to record to struct?
+
+A tuple expression can be used to initialize a structure or header type,
+in which case it is implicitly casted to a struct or header and its value is
+converted to a
 structure-valued expression (see [#sec-structure-expressions]):
 
 ~ Begin P4Example
@@ -5115,7 +5134,11 @@ sub-expression to an l-value, then evaluates its right sub-expression
 to a value, and finally copies the value into the l-value. Derived
 types (e.g. `structs`) are copied recursively, and all components
 of `header`s are copied, including "validity" bits. Assignment is
-not defined for `extern` values.
+not defined for `extern` values. If the type of the right sub-expression
+does not match the type of the left sub-expression, the right
+sub-expression will be implicitly casted to the type of the left
+sub-expression. If such implicit cast is illegal, then the assignment
+is illegal.
 
 ## Empty statement { #sec-empty-stmt }
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3907,8 +3907,6 @@ const S x = { 10, 20 }; //a = 10, b = 20
                         // implicit cast of type tuple to struct
 ~ End P4Example
 
-TODO!! is cast tuple to record to struct?
-
 A tuple expression can be used to initialize a structure or header type,
 in which case it is implicitly casted to a struct or header and its value is
 converted to a

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2175,15 +2175,18 @@ For example, the declaration
 
 ~ Begin P4Example
 enum bit<8> FailingExample {
-  first           = 1,
-  second          = 2,
-  third           = 3,
+  first           = 1,  // implicit cast converts 1 to 8w1
+  second          = 2,  // implicit cast converts 2 to 8w2
+  third           = 3,  // implicit cast converts 3 to 8w3
   unrepresentable = 300
 }
 ~ End P4Example
 
 would raise an error because `300`, the value associated with
 `FailingExample.unrepresentable` cannot be represented as a `bit<8>` value.
+Note that in order to represent the values of the other fields of
+`FailingExample` as `bit<8>` values the compiler inserts a cast
+of `int` to `bit<8>`. 
 
 The `initializer` expression must be a compile-time known value.
 
@@ -3688,24 +3691,44 @@ The following casts are legal in P4:
   sufficiently-large two's complement bit string to avoid information
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
+- `tuple` &rarr; `struct`: converts a list with `n` elements to a struct with `n` element. It associates the order of the elements in the list to the order of the elemenets in the struct.
+- `tuple` &rarr; `header`: converts a list with `n` elements to a header with `n` element. It associates the order of the elements in the list to the order of the elemenets in the header.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
 - casts from a typedef to the original type and vice versa.
 - casts from a type introduced by `type` to the original type and vice versa.
-- casts from an `enum` with an explicit type to its underlying type and vice versa.
+- casts from an `enum` with an underlying type to its underlying type and vice versa.
 - casts between two `enum` with the same underlying type.
+- recursively casting sub-parts of a type.
 
 
 ### Implicit casts { sec-implicit-casts }
 
-To keep the language simple and avoid introducing hidden costs, P4
-only implicitly casts from `int` to fixed-width types and from enums
+
+An implicit cast is the insertion of an explicit cast to an expression
+in a compiler's pass which raises when the complier tries to unify or infere types.
+Thus, there are no legal implicit casts that are illegal explicit casts. However,
+some legal explicit casts are illegal implicit casts. For example, two `enum`s with
+the same underlying type can be casted to each other explicitly but not implicitly.
+Implicitly casting types occurs
+
+- when unifying the types of expressions applied to an operator such as a binary operator
+- during assignment and initialization such as initializing the enum fields
+- during function call, method or constructor invocations.
+
+For example, P4
+implicitly casts from `int` to fixed-width types and from enums
 with an underlying type to the underlying type. In particular,
 applying a binary operation (except shifts and concatenation) to an expression of type `int` and an
 expression with a fixed-width type will implicitly cast the `int`
 expression to the type of the other expression. For enums with an underlying
-type, it can be implicitly cast to its underlying type whenever appropriate,
+type, they can be implicitly cast to their underlying type whenever appropriate,
 including but not limited to in shifts, concatenation, bit slicing indexes,
 header stack indexes as well as other unary and binary operations.
+As another example, when initializing a struct or header, P4 allows the use of a list (see [#sec-tuple-exprs], [#sec-ops-on-structs], [#sec-ops-on-hdrs]).
+
+Note that implicit cast occurs recursively, that is, if the top-level type
+does not require a cast insertion, still its sub-parts might require implicit casts
+(see example in [#sec-structure-expressions] or `FailingExample` in [#sec-enum-types]).
 
 For example, given the following declarations,
 
@@ -3899,7 +3922,10 @@ struct S {
 S s;
 
 // Compare s with a structure-valued expression
-bool b = s == (S) { a = 1, b = 2 };
+bool b = s == (S) { a = 1, b = 2 }; // implicit cast of int to bit<32>
+                                    // so that the type of a and b here
+                                    // matches the type of a and b in
+                                    // the declaration of S
 ~ End P4Example
 
 Structure-valued expressions can be used in the right-hand side of
@@ -4086,8 +4112,12 @@ struct S {
     bit<32> b;
 }
 const S x = { 10, 20 };             // tuple expression
+                                    // implicit cast of tuple to struct
+                                    // implicit cast of int to bit<32>
 const S x = { a = 10, b = 20 };     // structure-valued expression
+                                    // implicit cast of int to bit<32>
 const S x = (S) { a = 10, b = 20 }; // structure-valued expression
+                                    // implicit cast of int to bit<32>
 ~ End P4Example
 
 See Section [#sec-uninitialized-values-and-writing-invalid-headers]

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1797,7 +1797,7 @@ restricted places in P4 programs.
 
 ### The error type
 
-The error type contains opaque values that can be used to signal
+The error type contains opaque distinct values that can be used to signal
 errors. It is written as `error`. New constants of the error type
 are defined with the syntax:
 
@@ -1825,7 +1825,7 @@ The underlying representation of errors is target-dependent.
 ### The match kind type { #sec-match-kind-type }
 
 The `match_kind` type is very similar to the `error` type and
-is used to declare a set of names that may be
+is used to declare a set of distinct names that may be
 used in a table's key property (described in Section
 [#sec-table-props]).
 All identifiers are inserted into the
@@ -1936,10 +1936,12 @@ behavior should match this specification.
 
 An unsigned integer (which we also call a "bit-string") has an
 arbitrary width, expressed in bits. A bit-string of width `W` is
-declared as: `bit<W>`. `W` must be an expression that evaluates to a
+declared as: `bit<W>` or `bit< "(" expression ")" >`.
+`W` must be an expression that evaluates to a
 compile-time known value (see Section [#sec-ct-constants]) that is a
 non-negative integer.  When using an expression for
-the size, the expression must be parenthesized.  Bitstrings with width 0 are
+the size, the expression must be parenthesized and compile-time known that
+will evaluate to a non-negative integer.  Bitstrings with width 0 are
 allowed; they have no actual bits, and can only have the value 0.  See
 [#sec-uninitialized-values-and-writing-invalid-headers] for additional details.
 
@@ -1958,6 +1960,9 @@ significant.
 
 The type `bit` is a shorthand for `bit<1>`.
 
+The notation `bit<>` denotes a bit-string with width `W` which can be written
+as either `bit<W>` or `bit< "(" expression ")" >`.
+
 P4 architectures may impose additional constraints on bit types: for
 example, they may limit the maximum size, or they may only support
 some arithmetic operations on certain sizes (e.g., 16-, 32-, and 64-
@@ -1969,8 +1974,12 @@ described in Section [#sec-bit-ops].
 #### Signed Integers {#sec-signed-integers}
 
 Signed integers are represented using two's complement. An integer with `W`
-bits is declared as: `int<W>`. `W` must be an expression that evaluates to
+bits is declared as: `int<W>` or `int< "(" expression ") >.
+`W` must be an expression that evaluates to
 a compile-time known value that is a positive integer.
+When using an expression for
+the size, the expression must be parenthesized and compile-time known that
+will evaluate to a positive integer.
 
 Bits within an integer are numbered from `0` to `W-1`. Bit `0`
 is the least significant, and bit `W-1` is the sign bit.
@@ -1978,6 +1987,9 @@ is the least significant, and bit `W-1` is the sign bit.
 For example, the type `int<64>` describes the type of integers
 represented using exactly 64 bits with bits numbered from 0 to 63,
 where bit 63 is the most significant (sign) bit.
+
+The notation `int<>` denotes a signed integer with width `W` which can
+be written as either `int<W>` or `int< "(" expression ")" >`.
 
 P4 architectures may impose additional constraints on signed types:
 for example, they may limit the maximum size, or they may only support
@@ -1996,12 +2008,19 @@ Some network protocols use fields whose size is only known at runtime
 values, P4 provides a special bit-string type whose size is set at
 runtime, called a `varbit`.
 
-The type `varbit<W>` denotes a bit-string with a width of at most `W`
+The type `varbit<W>` or `varbit< "(" expression ")" >`
+denotes a bit-string with a width of at most `W`
 bits, where `W` must be a non-negative integer that is a compile-time
 known value. For example, the type `varbit<120>` denotes the type
-of bit-string values that may have between 0 and 120 bits. Most
-operations that are applicable to fixed-size bit-strings (unsigned
+of bit-string values that may have between 0 and 120 bits.
+When using an expression for
+the size, the expression must be parenthesized and compile-time known that
+will evaluate to a non-negative integer.
+Most operations that are applicable to fixed-size bit-strings (unsigned
 numbers) *cannot* be performed on dynamically sized bit-strings.
+
+The notation `varbit<>` denotes a dynamically-sized bit-string with width `W`
+which can be written as either `varbit<W>` or `varbit< "(" expression ")" >`.
 
 P4 architectures may impose additional constraints on varbit types:
 for example, they may limit the maximum size, or they may require `varbit`
@@ -2131,7 +2150,8 @@ enum Suits { Clubs, Diamonds, Hearths, Spades }
 introduces a new enumeration type, which contains four
 constants---e.g., `Suits.Clubs`. An `enum` declaration
 introduces a new identifier in the current scope for naming the
-created type.  The underlying representation of the `Suits` enum is not
+created type along with its distinct constants.
+The underlying representation of the `Suits` enum is not
 specified, so their "size" in bits is not specified (it is
 target-specific).
 
@@ -2141,8 +2161,8 @@ allowed to have fields with such `enum` types. This requires the programmer prov
 an associated integer value for each symbolic entry in the enumeration.
 The symbol `typeRef` in the grammar above must be one of the following types:
 
-- an unsigned integer, i.e. `bit<W>` for some constant `W`.
-- a signed integer, i.e. `int<W>` for some constant `W`.
+- an unsigned integer, i.e. `bit<>`.
+- a signed integer, i.e. `int<>`.
 - a type name declared via `typedef`, where the base type of that type is either
 one of the types listed above, or another `typedef` name that meets these conditions.
 For example, the declaration
@@ -2212,9 +2232,10 @@ syntax:
 where each `typeRef` is restricted to a bit-string type (fixed or
 variable), a fixed-width signed integer type, a boolean type, or a struct that
 itself contains other struct fields, nested arbitrarily, as long as all of the
-"leaf" types are `bit<W>`, `int<W>`, a serializable `enum`, or a `bool`. If a
+"leaf" types are `bit<>`, `int<>`, a serializable `enum`, or a `bool`. If a
 `bool` is used inside a P4 header, all implementations encode the `bool` as a
 one bit long field, with the value `1` representing `true` and `0` representing `false`.
+Field names have to be distinct.
 
 A header declaration introduces a new identifier in the
 current scope; the type can be referred to using this identifier. A header is
@@ -2337,7 +2358,7 @@ defined as:
 [INCLUDE=grammar.mdk:headerStackType]
 ~ End P4Grammar
 
-where `typeName` is the name of a header type. For a header stack `hs[n]`,
+where `typeName` is the name of a header or a header union type. For a header stack `hs[n]`,
 the term `n` is the maximum defined size, and must be
 a positive integer that is a compile-time known value. Nested header
 stacks are not supported. At runtime a stack contains `n` values
@@ -2375,6 +2396,7 @@ A header union is defined as:
 This declaration introduces a new type with the specified name in the
 current scope. Each element of the list of fields used to declare a
 header union must be of header type. An empty list of fields is legal.
+Field names have to be distinct.
 
 As an example, the type `Ip_h` below represents the union of an IPv4
 and IPv6 headers:
@@ -2397,7 +2419,7 @@ P4 `struct` types are defined with the following syntax:
 ~ End P4Grammar
 
 This declaration introduces a new type with the specified name in the
-current scope. An empty struct (with no fields) is legal. For example, the structure `Parsed_headers`
+current scope. Field names have to be distinct. An empty struct (with no fields) is legal. For example, the structure `Parsed_headers`
 below contains the headers recognized by a simple parser:
 
 ~ Begin P4Example
@@ -2453,34 +2475,34 @@ header unions, structs, tuples, and lists.  Note that `int` by itself
 (i.e. not as part of an `int<N>` type expression) means an
 arbitrary-precision integer, without a width specified.
 
-|--------------------|------------------------------------------------||||
-|                    | Container type                                 ||||
-|                    |-----------|--------------|-----------------|------|
-| Element type       | header    | header_union | struct or tuple | list |
-+:-------------------+:----------+:-------------+:----------------+:-----+
-| `bit<W>`       | allowed   | error   |  allowed | allowed |
-| `int<W>`       | allowed   | error   |  allowed | allowed |
-| `varbit<W>`    | allowed   | error   |  allowed | allowed |
-| `int`          | error     | error   |  error   | allowed |
-| `void`         | error     | error   |  error   | error   |
-| `string`       | error     | error   |  error   | allowed |
-| `error`        | error     | error   |  allowed | allowed |
-| `match_kind`   | error     | error   |  error   | allowed |
-| `bool`         | allowed   | error   |  allowed | allowed |
-| `enum`         | allowed[^enum_header]     | error   |  allowed | allowed |
-| `header`       | error     | allowed |  allowed | allowed |
-| header stack   | error     | error   |  allowed | allowed |
-| `header_union` | error     | error   |  allowed | allowed |
-| `struct`       | allowed[^struct_header]   | error   |  allowed | allowed |
-| `tuple`        | error     | error   |  allowed | allowed |
-| `list`         | error     | error   |  error   | allowed |
-|----------------|-----------|---------|----------|---------|
+|--------------------|------------------------------------------------|||||
+|                    | Container type                                 |||||
+|                    |-----------|--------------|-----------------|------|--------------|
+| Element type       | header    | header_union | struct or tuple | list | header stack |
++:-------------------+:----------+:-------------+:----------------+:-----+:-------------+
+| `bit<>`       | allowed   | error   |  allowed | allowed | error |
+| `int<>`       | allowed   | error   |  allowed | allowed | error |
+| `varbit<>`    | allowed   | error   |  allowed | allowed | error |
+| `int`          | error     | error   |  error   | allowed | error |
+| `void`         | error     | error   |  error   | error   | error |
+| `string`       | error     | error   |  error   | allowed | error |
+| `error`        | error     | error   |  allowed | allowed | error |
+| `match_kind`   | error     | error   |  error   | allowed | error |
+| `bool`         | allowed   | error   |  allowed | allowed | error |
+| `enum`         | allowed[^enum_header]     | error   |  allowed | allowed | error |
+| `header`       | error     | allowed |  allowed | allowed | allowed |
+| header stack   | error     | error   |  allowed | allowed | error |
+| `header_union` | error     | error   |  allowed | allowed | allowed |
+| `struct`       | allowed[^struct_header]   | error   |  allowed | allowed | error |
+| `tuple`        | error     | error   |  allowed | allowed | error | 
+| `list`         | error     | error   |  error   | allowed | error |
+|----------------|-----------|---------|----------|---------|-------|
 
 [^enum_header]: an `enum` type used as a field in a `header` must specify a
     underlying type and representation for `enum` elements.
 [^struct_header]: a `struct` or nested `struct` type that has the same properties,
     used as a field in a `header` must contain only
-    `bit<W>`, `int<W>`, a serializable `enum`, or a `bool`.
+    `bit<>`, `int<>`, a serializable `enum`, or a `bool`.
 
 
 Rationale: `int` does not have precise storage requirements,
@@ -2500,12 +2522,12 @@ The table below lists all types that may appear as base types in a
 `typedef` or `type` declaration.
 
 
-|------------------|--------------------------------------|
+|------------------|--------------------|-----------------|
 | Base type B      | `typedef B <name>` | `type B <name>` |
 +:-----------------+:-------------------+:----------------+
-| `bit<W>`         | allowed            | allowed         |
-| `int<W>`         | allowed            | allowed         |
-| `varbit<W>`      | allowed            | error           |
+| `bit<>`         | allowed            | allowed         |
+| `int<>`         | allowed            | allowed         |
+| `varbit<>`      | allowed            | error           |
 | `int`            | allowed            | error           |
 | `void`           | error              | error           |
 | `error`          | allowed            | error           |
@@ -3302,8 +3324,8 @@ expression can be inferred statically at compile time.
 ## Operations on fixed-width bit types (unsigned integers) { #sec-bit-ops }
 
 This section discusses all operations that can be performed on
-expressions of type `bit<W>` for some width `W`, also known as
-bit-strings.
+expressions of type `bit<>` of width `W`, also known as
+bit-strings. 
 
 Arithmetic operations "wrap around", similar to C operations on
 unsigned values (i.e., representing a large value on W bits will only
@@ -3385,12 +3407,12 @@ Bit-strings also support the following operations:
 
   - `int` - an arbitrary-precision integer
     (section [#sec-arbitrary-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0`
+  - `bit<>` - a `W`-bit unsigned integer where `W >= 0`
     (section [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where `W >= 1`
+  - `int<>` - a `W`-bit signed integer where `W >= 1`
     (section [#sec-signed-integers])
   - a serializable `enum` with an underlying type that is
-    `bit<W>` or `int<W>` (section [#sec-enum-types]).
+    `bit<>` or `int<>` (section [#sec-enum-types]).
 
   The result is a bit-string of width `H - L + 1`, including the bits numbered
   from `L` (which becomes the least significant bit of the result) to `H` (the
@@ -3405,15 +3427,15 @@ Bit-strings also support the following operations:
   both) of `e` to the bit-pattern represented by `x`, and leaves all other bits
   of `e` unchanged.  A slice of an unsigned integer is an unsigned integer.
 - Concatenation of bit-strings and/or fixed-width signed integers, denoted by `++`.
-  The two operands must be either `bit<W>` or `int<W>`, and they can be of
+  The two operands must be either `bit<>` or `int<>`, and they can be of
   different signedness and width.  The result has the same signedness as the
   left operand and the width equal to the sum of the two operands' width.
   In concatenation, the left operand is placed as the most significant bits.
 
 ## Operations on fixed-width signed integers { #sec-int-ops }
 
-This section discusses all operations that can be performed on expressions of type `int<W>`
-for some `W`. Recall that the `int<W>` denotes signed `W`-bit integers,
+This section discusses all operations that can be performed on expressions of type `int<>`
+with width `W`. Recall that the `int<>` with width `W` denotes signed `W`-bit integers,
 represented using two's complement.
 
 In general, P4 arithmetic operations do not detect "underflow" or "overflow":
@@ -3461,7 +3483,7 @@ type. The result always has the same width as the left operand.
 - Saturating addition, denoted by `|+|`.
 - Saturating subtraction, denoted by `|-|`.
 
-The `int<W>` datatype also support the following operations:
+The `int<>` datatype also support the following operations:
 
 - Arithmetic shift left and right denoted by `<<` and `>>`.
   The left operand is signed and the right operand must be either an
@@ -3483,11 +3505,11 @@ The `int<W>` datatype also support the following operations:
 
   - `int` - an arbitrary-precision integer
     (section [#sec-arbitrary-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0`
+  - `bit<>` - a `W`-bit unsigned integer where `W >= 0`
     (section [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where `W >= 1`
+  - `int<>` - a `W`-bit signed integer where `W >= 1`
     (section [#sec-signed-integers])
-  - a serializable `enum` with an underlying type that is `bit<W>` or `int<W>`
+  - a serializable `enum` with an underlying type that is `bit<>` or `int<>`
     (section [#sec-enum-types]).
 
   The result is an unsigned bit-string of width `H - L + 1`, including the bits
@@ -3503,7 +3525,7 @@ The `int<W>` datatype also support the following operations:
   bit-pattern represented by `x`, and leaves all other bits of `e` unchanged.
   A slice of a signed integer is treated as an unsigned integer.
 - Concatenation of bit-strings and/or fixed-width signed integers, denoted by `++`.
-  The two operands must be either `bit<W>` or `int<W>`, and they can be of different signedness and width.
+  The two operands must be either `bit<>` or `int<>`, and they can be of different signedness and width.
   The result has the same signedness as the left operand and the width equal to the sum of the two operands' width.
   In concatenation, the left operand is placed as the most significant bits.
 
@@ -3534,11 +3556,11 @@ expressions of type `int` must be compile-time known values.  The type
 
   - `int` - an arbitrary-precision integer
     (section [#sec-arbitrary-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0`
+  - `bit<>` - a `W`-bit unsigned integer where `W >= 0`
     (section [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where `W >= 1`
+  - `int<>` - a `W`-bit signed integer where `W >= 1`
     (section [#sec-signed-integers])
-  - a serializable `enum` with an underlying type that is `bit<W>` or `int<W>`
+  - a serializable `enum` with an underlying type that is `bit<>` or `int<>`
     (section [#sec-enum-types]).
 
   The result is an unsigned bit-string of width `H - L + 1`, including the bits
@@ -3690,22 +3712,24 @@ While this design is arguably more onerous for programmers, it has several benef
 The following casts are legal in P4:
 
 - `bit<1>` &harr; `bool`: converts the value `0` to `false`, the value `1` to `true`, and vice versa.
-- `int` &rarr; `bool`: only if the `int` value is `0` (converted to `false`) or `1` (converted to `true`)
+- `int` &rarr; `bool`: only if the `int` value is `0` (converted to `false`) or `1` (converted to `true`).
 - `int<W>` &rarr; `bit<W>`: preserves all bits unchanged and reinterprets negative
-  values as positive values
-- `bit<W>` &rarr; `int<W>`: preserves all bits unchanged and reinterprets values whose most-significant bit is `1` as negative values
-- `bit<W>` &rarr; `bit<X>`: truncates the value if `W > X`, and otherwise (i.e., if  `W <= X`) pads the value with zero bits.
-- `int<W>` &rarr; `int<X>`: truncates the value if `W > X`, and otherwise (i.e., if `W < X`) extends it with the sign bit.
-- `bit<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result is always non-negative
-- `int<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result may be negative
+  values as positive values. Note that `W` can be an integer or an expression that will evaluate to an integer.
+- `bit<W>` &rarr; `int<W>`: preserves all bits unchanged and reinterprets values whose most-significant bit is `1` as negative values. Note that `W` can be an integer or an expression that will evaluate to an integer.
+- `bit<W>` &rarr; `bit<X>`: truncates the value if `W > X`, and otherwise (i.e., if  `W <= X`) pads the value with zero bits. Note that `W` and `X` can be an integer or an expression that will evaluate to an integer.
+- `int<W>` &rarr; `int<X>`: truncates the value if `W > X`, and otherwise (i.e., if `W < X`) extends it with the sign bit. Note that `W` and `X` can be an integer or an expression that will evaluate to an integer.
+- `bit<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result is always non-negative. Note that `W` can be an integer or an expression that will evaluate to an integer.
+- `int<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result may be negative. Note that `W` can be an integer or an expression that will evaluate to an integer.
 - `int` &rarr; `bit<W>`: converts the integer value into a sufficiently
   large two's complement bit string to avoid information loss,
   and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow or on conversion of negative value.
+  Note that `W` can be an integer or an expression that will evaluate to an integer.
 - `int` &rarr; `int<W>`: converts the integer value into a
   sufficiently-large two's complement bit string to avoid information
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
+  Note that `W` can be an integer or an expression that will evaluate to an integer.
 - `tuple` &rarr; `struct`: converts a list with `n` elements to a struct with `n` element. It associates the order of the elements in the list to the order of the elemenets in the struct.
 - `tuple` &rarr; `header`: converts a list with `n` elements to a header with `n` element. It associates the order of the elements in the list to the order of the elemenets in the header.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
@@ -4046,7 +4070,7 @@ select (hdr.ipv4.version) {
 
 ### Masks { #sec-cubes }
 
-The infix operator `&&&` takes two arguments of type `bit<W>` or
+The infix operator `&&&` takes two arguments of type `bit<>` or
 serializable `enum`, and creates a value of type `set<ltype>`, where
 ltype is the type of the left argument.  The right value is used as a
 "mask", where each bit set to `0` in the mask indicates a "don't care"
@@ -4077,7 +4101,7 @@ values.
 ### Ranges { #sec-ranges }
 
 The infix operator `..` takes two arguments of the same type `T`,
-where `T` is either `bit<W>`, `int<W>`, or a serializable enum value,
+where `T` is either `bit<>`, `int<>`, or a serializable enum value,
 and creates a value of type `set<T>`. The set contains all values
 numerically between the first and the second, inclusively. For
 example:
@@ -4226,9 +4250,9 @@ expressions are legal:
   The `index` is an expression that must be one of the following types:
 
   - `int` - an arbitrary-precision integer (Section [#sec-arbitrary-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where W≥0 (Section [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where W≥1 (Section [#sec-signed-integers])
-  - a serializable `enum` with an underlying type that is `bit<W>` or `int<W>` where W≥1 (Section [#sec-enum-types]).
+  - `bit<>` - a `W`-bit unsigned integer where `W >= 0` (Section [#sec-unsigned-integers])
+  - `int<>` - a `W`-bit signed integer where `W >= 1` (Section [#sec-signed-integers])
+  - a serializable `enum` with an underlying type that is `bit<>` or `int<>` where `W >= 1` (Section [#sec-enum-types]).
 
 - `hs.size`: produces a 32-bit unsigned integer that returns the
   size of the header stack (a compile-time constant).
@@ -5303,8 +5327,8 @@ table missed and the `default_action` was executed.
 For this variant of `switch` statement, the expression must evaluate
 to a result with one of these types:
 
-- `bit<W>`
-- `int<W>`
+- `bit<>`
+- `int<>`
 - `enum`, either with or without an underlying representation specified
 - `error`
 
@@ -5564,8 +5588,8 @@ expression is as follows:
 [INCLUDE=grammar.mdk:selectCase]
 ~ End P4Grammar
 
-Each expression in the `expressionList` must have a type of `bit<W>`,
-`int<W>`, `bool`, `enum`, serializable `enum`, or a `tuple` type with
+Each expression in the `expressionList` must have a type of `bit<>`,
+`int<>`, `bool`, `enum`, serializable `enum`, or a `tuple` type with
 fields of one of the above types.
 
 In a `select` expression, if the `expressionList` has type `tuple<T>`,


### PR DESCRIPTION
This PR addresses some of the issues mentioned in #1223. Specifically, it addresses the following:

- Uses consistent terminology to talk about the implicit cast
- Expands explicit cast enumeration
- Adds comments in some examples where implicit cast occurs
- Adds the recursiveness of casting

Some questions arose while formalizing some of P4 which are related to this PR:
- [x] Should we add record types (or anonymous header types) so that we can explicitly add them to the casting section, instead of dancing around it every time we use record types to initialize a struct or header? Discussed this in the LDWG meeting on March 6th. Not sure if there's a consensus. Suggestion: propose the change in a PR. 
- [x] Other than the potential casting of the subtypes of a list, can a list be casted to another type or be the result of a cast? No, it seems that the value of a list can only be written using an explicit cast expression, however, I don't think spec defines it as such. It seems that that's just part of the syntax.
- [x] Are there any restrictions for the nesting of generic types? No, this is checked when types are instantiated.