### PR TITLE
Clarify fixed length types

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3731,10 +3731,9 @@ The following casts are legal in P4:
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
-- casts from a typedef to the original type and vice versa.
-- casts from a type introduced by `type` to the original type and vice versa.
-- casts from an `enum` with an explicit type to its underlying type and vice versa.
-- casts between two `enum` with the same underlying type.
+- casts between a typedef to the original type.
+- casts between a type introduced by `type` to the original type.
+- casts between an `enum` with an explicit type to its underlying type
 
 
 ### Implicit casts { sec-implicit-casts }
@@ -3797,7 +3796,6 @@ several ways that the expression could be manually rewritten into a
 legal expression. Note that for some expression there are several
 legal alternatives, which may produce different results! The compiler
 cannot guess the user intent, so P4 requires the user to disambiguate.
-Thus, it cannot insert implicit casts to make the expression legal.
 
 |-----|-----|-----|
 | Expression | Why it is illegal  | Alternatives |

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3731,9 +3731,9 @@ The following casts are legal in P4:
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
-- casts between a typedef to the original type.
-- casts between a type introduced by `type` to the original type.
-- casts between an `enum` with an explicit type to its underlying type
+- casts between a typedef and the original type.
+- casts between a type introduced by `type` and the original type.
+- casts between an `enum` with an explicit type and its underlying type
 
 
 ### Implicit casts { sec-implicit-casts }

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3689,9 +3689,11 @@ The following casts are legal in P4:
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
-- casts between a typedef and the original type.
-- casts between a type introduced by `type` and the original type.
-- casts between an `enum` with an explicit type and its underlying type
+- casts from a typedef to the original type and vice versa.
+- casts from a type introduced by `type` to the original type and vice versa.
+- casts from an `enum` with an explicit type to its underlying type and vice versa.
+- casts between two `enum` with the same underlying type.
+
 
 ### Implicit casts { sec-implicit-casts }
 
@@ -3753,6 +3755,7 @@ several ways that the expression could be manually rewritten into a
 legal expression. Note that for some expression there are several
 legal alternatives, which may produce different results! The compiler
 cannot guess the user intent, so P4 requires the user to disambiguate.
+Thus, it cannot insert implicit casts to make the expression legal.
 
 |-----|-----|-----|
 | Expression | Why it is illegal  | Alternatives |

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1995,7 +1995,7 @@ Bitstrings with width 0 are
 allowed; they have no actual bits, and can only have the value 0.  See
 [#sec-uninitialized-values-and-writing-invalid-headers] for additional details.
 Note that `bit<W>` type refers to both cases of `bit<W>`
-and `bit< "(" expression ")" > where the width is compile-time known.
+and `bit<(expression)>` where the width is compile-time known.
 
 ~ Begin P4Example
 const bit<32> x = 10;   // 32-bit constant with value 10.
@@ -2026,7 +2026,7 @@ Signed integers are represented using two's complement. An integer with `W`
 bits is declared as: `int<W>`. `W` must be an expression that evaluates to
 a compile-time known value that is a positive integer.
 Note that `int<W>` type refers to both cases of `int<W>`
-and `int< "(" expression ")" > where the width is compile-time known.
+and `int<(expression)>` where the width is compile-time known.
 
 Bits within an integer are numbered from `0` to `W-1`. Bit `0`
 is the least significant, and bit `W-1` is the sign bit.
@@ -2059,7 +2059,7 @@ of bit-string values that may have between 0 and 120 bits. Most
 operations that are applicable to fixed-size bit-strings (unsigned
 numbers) *cannot* be performed on dynamically sized bit-strings.
 Note that `varbit<W>` type refers to both cases of `varbit<W>`
-and `varbit< "(" expression ")" > where the width is compile-time known.
+and `varbit<(expression)>` where the width is compile-time known.
 
 P4 architectures may impose additional constraints on varbit types:
 for example, they may limit the maximum size, or they may require `varbit`

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1974,9 +1974,12 @@ arbitrary width, expressed in bits. A bit-string of width `W` is
 declared as: `bit<W>`. `W` must be an expression that evaluates to a
 compile-time known value (see Section [#sec-ct-constants]) that is a
 non-negative integer.  When using an expression for
-the size, the expression must be parenthesized.  Bitstrings with width 0 are
+the size, the expression must be parenthesized and compile-time known.
+Bitstrings with width 0 are
 allowed; they have no actual bits, and can only have the value 0.  See
 [#sec-uninitialized-values-and-writing-invalid-headers] for additional details.
+Note that `bit<W>` type refers to both cases of `bit<W>`
+and `bit< "(" expression ")" > where the width is compile-time known.
 
 ~ Begin P4Example
 const bit<32> x = 10;   // 32-bit constant with value 10.
@@ -2006,6 +2009,8 @@ described in Section [#sec-bit-ops].
 Signed integers are represented using two's complement. An integer with `W`
 bits is declared as: `int<W>`. `W` must be an expression that evaluates to
 a compile-time known value that is a positive integer.
+Note that `int<W>` type refers to both cases of `int<W>`
+and `int< "(" expression ")" > where the width is compile-time known.
 
 Bits within an integer are numbered from `0` to `W-1`. Bit `0`
 is the least significant, and bit `W-1` is the sign bit.
@@ -2024,7 +2029,7 @@ in Section [#sec-int-ops].
 
 A signed integer with width 1 can only have two legal values: 0 and -1.
 
-#### Dynamically-sized bit-strings
+#### Dynamically-sized bit-strings { #sec-dynamically-sized-integers }
 
 Some network protocols use fields whose size is only known at runtime
 (e.g., IPv4 options). To support restricted manipulations of such
@@ -2037,6 +2042,8 @@ known value. For example, the type `varbit<120>` denotes the type
 of bit-string values that may have between 0 and 120 bits. Most
 operations that are applicable to fixed-size bit-strings (unsigned
 numbers) *cannot* be performed on dynamically sized bit-strings.
+Note that `varbit<W>` type refers to both cases of `varbit<W>`
+and `varbit< "(" expression ")" > where the width is compile-time known.
 
 P4 architectures may impose additional constraints on varbit types:
 for example, they may limit the maximum size, or they may require `varbit`
@@ -2176,8 +2183,8 @@ allowed to have fields with such `enum` types. This requires the programmer prov
 an associated integer value for each symbolic entry in the enumeration.
 The symbol `typeRef` in the grammar above must be one of the following types:
 
-- an unsigned integer, i.e. `bit<W>` for some constant `W`.
-- a signed integer, i.e. `int<W>` for some constant `W`.
+- an unsigned integer, i.e. `bit<W>` for some compile-time known `W`.
+- a signed integer, i.e. `int<W>` for some compile-time known `W`.
 - a type name declared via `typedef`, where the base type of that type is either
 one of the types listed above, or another `typedef` name that meets these conditions.
 For example, the declaration
@@ -4212,9 +4219,9 @@ expressions are legal:
   The `index` is an expression that must be one of the following types:
 
   - `int` - an arbitrary-precision integer (Section [#sec-arbitrary-precision-integers])
-  - `bit<W>` - a `W`-bit unsigned integer where W≥0 (Section [#sec-unsigned-integers])
-  - `int<W>` - a `W`-bit signed integer where W≥1 (Section [#sec-signed-integers])
-  - a serializable `enum` with an underlying type that is `bit<W>` or `int<W>` where W≥1 (Section [#sec-enum-types]).
+  - `bit<W>` - a `W`-bit unsigned integer where `W >= 0` (Section [#sec-unsigned-integers])
+  - `int<W>` - a `W`-bit signed integer where `W >= 1` (Section [#sec-signed-integers])
+  - a serializable `enum` with an underlying type that is `bit<W>` or `int<W>` (Section [#sec-enum-types]).
 
 - `hs.size`: produces a 32-bit unsigned integer that returns the
   size of the header stack (a compile-time constant).
@@ -8138,6 +8145,7 @@ The P4 compiler should provide:
 
 ## Summary of changes made in version 1.2.4
 
+* Clarified types `bit<W>`, `int<W>`, and `varbit<W>` encompass the case where the width is a compile-time known expression evaluating to an appropriate integer (Section [#sec-unsigned-integers], Section [#sec-signed-integers], Section [#sec-dynamically-sized-integers]).
 * Added optional trailing commas (Section [# sec-trailing-commas])
 * Clarified the scope of parser namespaces (Section [#sec-parser-decl]).
 * Specified that algorithm for generating control-plane names for keys is optional (Section [#sec-cp-keys]).


### PR DESCRIPTION
This PR clarifies the use of `bit<W>`, `int<W>`, and `varbit<W>`. More specifically, it states that these represent the case where the width of the type is either a constant integer or a compile-time known expression that evaluates to an integer. In other words, it addresses issue #1228.