### PR TITLE
Fix cast

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3689,9 +3689,11 @@ The following casts are legal in P4:
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
-- casts between a typedef and the original type.
-- casts between a type introduced by `type` and the original type.
-- casts between an `enum` with an explicit type and its underlying type
+- casts from a typedef to the original type and vice versa.
+- casts from a type introduced by `type` to the original type and vice versa.
+- casts from an `enum` with an explicit type to its underlying type and vice versa.
+- casts between two `enum` with the same underlying type.
+
 
 ### Implicit casts { sec-implicit-casts }
 
@@ -3753,6 +3755,7 @@ several ways that the expression could be manually rewritten into a
 legal expression. Note that for some expression there are several
 legal alternatives, which may produce different results! The compiler
 cannot guess the user intent, so P4 requires the user to disambiguate.
+Thus, it cannot insert implicit casts to make the expression legal.
 
 |-----|-----|-----|
 | Expression | Why it is illegal  | Alternatives |

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2175,9 +2175,9 @@ For example, the declaration
 
 ~ Begin P4Example
 enum bit<8> FailingExample {
-  first           = 1, // implicit cast converts 1 to 8w1
-  second          = 2, // implicit cast converts 1 to 8w2
-  third           = 3, // implicit cast converts 1 to 8w3
+  first           = 1, // implicit cast of int to bit<8> converts 1 to 8w1
+  second          = 2, // implicit cast of int to bit<8> converts 1 to 8w2
+  third           = 3, // implicit cast of int to bit<8> converts 1 to 8w3
   unrepresentable = 300
 }
 ~ End P4Example
@@ -2185,8 +2185,8 @@ enum bit<8> FailingExample {
 would raise an error because `300`, the value associated with
 `FailingExample.unrepresentable` cannot be represented as a `bit<8>` value.
 Note that in order to represent the values of the other fields of
-`FailingExample` as `bit<8>` values the compiler inserts a cast
-of `int` to `bit<8>`.
+`FailingExample` as `bit<8>` values, the compiler implicitly casts
+type `int` to `bit<8>`.
 
 The `initializer` expression must be a compile-time known value.
 
@@ -2910,7 +2910,8 @@ new type.
 
 ~ Begin P4Example
 type bit<32> U32;
-U32 x = (U32)0;
+U32 x = (U32)0; // implicit cast of int to bit<32> converts 0 to 32w0
+                // explicit cast of bit<32> to U32
 ~ End P4Example
 
 While similar to `typedef`, the `type` keyword introduces a new type
@@ -2936,7 +2937,7 @@ This declaration will prevent `PortId_t` values from being used in
 arithmetic expressions without casts.  Moreover, this declaration may enable special
 manipulation or such values by software that lies outside of the
 datapath (e.g., a target-specific toolchain could include software
-that automatically converts values of type `PortId_t` to a different
+that implicitly casts type `PortId_t` to a different
 representation when exchanged with the control-plane software).
 
 # Expressions { #sec-exprs }
@@ -3072,9 +3073,9 @@ An `enum` may also specify an underlying type, such as the following:
 
 ~ Begin P4Example
 enum bit<8> E {
-  e1 = 0,
-  e2 = 1,
-  e3 = 2
+  e1 = 0, // implicit cast of int to bit<8> converts 0 to 8w0
+  e2 = 1, // implicit cast of int to bit<8> converts 1 to 8w1
+  e3 = 2  // implicit cast of int to bit<8> converts 2 to 8w2
 }
 ~ End P4Example
 
@@ -3110,10 +3111,11 @@ Because it is always safe to cast from an `enum` to its underlying fixed-width i
 implicit casting from an `enum` to its fixed-width (signed or unsigned) integer type is also supported (see Section [#sec-implicit-casts]):
 
 ~ Begin P4Example
-bit<8> x = E.e2; // sets x to 1 (E.e2 is automatically casted to bit<8>)
+bit<8> x = E.e2; // sets x to 1 (E.e2 is implicitly casted to bit<8>)
 
 E  a = E.e2
-bit<8> y = a << 3; // sets y to 8 (a is automatically casted to bit<8> and then shifted)
+bit<8> y = a << 3; // sets y to 8
+                   // (a is implicitly casted to bit<8> and then shifted)
 ~ End P4Example
 
 Implicit casting from an underlying fixed-width type to an enum is *not* supported.
@@ -3129,20 +3131,21 @@ enum bit<8> E2 {
 E1 a = E1.e1;
 E2 b = E2.e2;
 
-a = b;      // Error: b is automatically casted to bit<8>,
-            // but bit<8> cannot be automatically casted to E1
+a = b;      // Error: b is implicitly casted to bit<8>,
+            // but bit<8> cannot be implicitly casted to E1.
 
 a = (E1) b; // OK
 
-a = E1.e1 + 1; // Error: E.e1 is automatically casted to bit<8>,
-               // and the right-hand expression has
-               // the type bit<8>, which cannot be casted to E automatically.
+a = E1.e1 + 1; // Error: E.e1 is implicitly casted to bit<8>,
+               // 1 is converted to 8w1 (int is implicitly casted to bit<8>),
+               // thus, the right-hand expression has
+               // the type bit<8>, but it cannot be implicitly casted to E1.
 
-a = (E1)(E1.e1 + 1); // Final explicit casting makes the assignment legal
+a = (E1)(E1.e1 + 1); // Final explicit casting makes the assignment legal.
 
-a = E1.e1 + E1.e2; // Error: both arguments to the addition are automatically
-                   // casted to bit<8>. Thus the addition itself is legal, but
-                   // the assignment is not
+a = E1.e1 + E1.e2; // Error: both arguments to the addition are implicitly
+                   // casted to bit<8>. Thus, the addition itself is legal, but
+                   // the assignment is not.
 
 a = (E1)(E2.e1 + E2.e2); //  Final explicit casting makes the assignment legal
 ~ End P4Example
@@ -3154,7 +3157,7 @@ E1     a = E1.e1;
 E2     b = E2.e2;
 bit<8> c;
 
-if (a > b) { // Potential warning: two automatic and different casts to bit<8>.
+if (a > b) { // Potential warning: two implicit and different casts to bit<8>.
    // code omitted
 }
 
@@ -3555,7 +3558,7 @@ expressions of type `int` must be compile-time known values.  The type
 Each operand that participates in any of these operation must have
 type `int` (except shifts). Binary operations cannot
 be used to combine values of type `int` with values of a fixed-width
-type (except shifts). However, the compiler automatically inserts casts from `int`
+type (except shifts). However, the compiler implicitly casts type `int`
 to fixed-width types in certain situations---see Section [#sec-casts].
 
 All computations on `int` values are carried out without loss of

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2184,6 +2184,9 @@ enum bit<8> FailingExample {
 
 would raise an error because `300`, the value associated with
 `FailingExample.unrepresentable` cannot be represented as a `bit<8>` value.
+Note that in order to represent the values of the other fields of
+`FailingExample` as `bit<8>` values the compiler inserts a cast
+of `int` to `bit<8>`.
 
 The `initializer` expression must be a compile-time known value.
 
@@ -3688,24 +3691,44 @@ The following casts are legal in P4:
   sufficiently-large two's complement bit string to avoid information
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
+- `tuple` &rarr; `struct`: converts a tuple with `n` elements to a struct with `n` element. It associates the order of the elements in the list to the order of the elemenets in the struct.
+- `tuple` &rarr; `header`: converts a tuple with `n` elements to a header with `n` element. It associates the order of the elements in the list to the order of the elemenets in the header.
+- `tuple` &rarr; `anonymous header`: converts a tuple with `n` elements to a header with `n` element. It associates the order of the elements in the list to the order of the elemenets in the header. TODO.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
 - casts from a typedef to the original type and vice versa.
 - casts from a type introduced by `type` to the original type and vice versa.
-- casts from an `enum` with an explicit type to its underlying type and vice versa.
+- casts from an `enum` with an underlying type to its underlying type and vice versa.
 - casts between two `enum` with the same underlying type.
+- recursively casting sub-parts of a type.
 
 
 ### Implicit casts { sec-implicit-casts }
 
-To keep the language simple and avoid introducing hidden costs, P4
-only implicitly casts from `int` to fixed-width types and from enums
+An implicit cast is the insertion of an explicit cast to an expression
+in a compiler's pass which raises when the complier tries to unify or infere types.
+Thus, there are no legal implicit casts that are illegal explicit casts. However,
+some legal explicit casts are illegal implicit casts. For example, two `enum`s with
+the same underlying type can be casted to each other explicitly but not implicitly.
+Implicitly casting types occurs
+
+- when unifying the types of expressions applied to an operator such as a binary operator
+- during assignment and initialization such as initializing the enum fields
+- during function call, method or constructor invocations.
+
+For example, P4
+implicitly casts from `int` to fixed-width types and from enums
 with an underlying type to the underlying type. In particular,
 applying a binary operation (except shifts and concatenation) to an expression of type `int` and an
 expression with a fixed-width type will implicitly cast the `int`
 expression to the type of the other expression. For enums with an underlying
-type, it can be implicitly cast to its underlying type whenever appropriate,
+type, they can be implicitly cast to their underlying type whenever appropriate,
 including but not limited to in shifts, concatenation, bit slicing indexes,
 header stack indexes as well as other unary and binary operations.
+As another example, when initializing a struct or header, P4 allows the use of a list (see [#sec-tuple-exprs], [#sec-ops-on-structs], [#sec-ops-on-hdrs]).
+
+Note that implicit cast occurs recursively, that is, if the top-level type
+does not require a cast insertion, still its sub-parts might require implicit casts
+(see example in [#sec-structure-expressions] or `FailingExample` in [#sec-enum-types]).
 
 For example, given the following declarations,
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3922,7 +3922,10 @@ struct S {
 S s;
 
 // Compare s with a structure-valued expression
-bool b = s == (S) { a = 1, b = 2 };
+bool b = s == (S) { a = 1, b = 2 }; // implicit cast of int to bit<32>
+                                    // so that the type of a and b here
+                                    // matches the type of a and b in
+                                    // the declaration of S
 ~ End P4Example
 
 Structure-valued expressions can be used in the right-hand side of
@@ -4109,8 +4112,12 @@ struct S {
     bit<32> b;
 }
 const S x = { 10, 20 };             // tuple expression
+                                    // implicit cast of tuple to struct
+                                    // implicit cast of int to bit<32>
 const S x = { a = 10, b = 20 };     // structure-valued expression
+                                    // implicit cast of int to bit<32>
 const S x = (S) { a = 10, b = 20 }; // structure-valued expression
+                                    // implicit cast of int to bit<32>
 ~ End P4Example
 
 See Section [#sec-uninitialized-values-and-writing-invalid-headers]

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3661,9 +3661,24 @@ finding this information in a section dedicated to type `varbit`.
 
 ## Casts { #sec-casts }
 
-P4 provides a limited set of casts between types. A cast is written
-`(t) e`, where `t` is a type and `e` is an expression. Casts are only
-permitted on base types and derived types introduced by `typedef`, `type`, and `enum`.
+P4 provides a limited set of casts between types. The syntax of a cast is given by:
+
+~ Begin P4Grammar
+expression ...
+    | '(' typeRef ')' expression
+    ;
+
+~ End P4Grammar
+
+The `typeRef` is a type or a name associated to a type.
+More specifically, it can be
+
+- a base type or a `tuple` type
+- a name that represents an `enum`, `struct`, `header`
+- a name representing a derived type introduced by `typedef` or `type`
+
+P4 provides a limited set of legal casts between types which are
+enumerated in Section [#sec-explicit-cast].
 While this design is arguably more onerous for programmers, it has several benefits:
 
 - It makes user intent unambiguous.
@@ -3673,30 +3688,31 @@ While this design is arguably more onerous for programmers, it has several benef
 - It reduces the number of cases that have to be considered in the P4
   specification. Some targets may not support all casts.
 
-### Explicit casts
+### Explicit casts { #sec-explicit-cast }
 
 The following casts are legal in P4:
 
 - `bit<1>` &harr; `bool`: converts the value `0` to `false`, the value `1` to `true`, and vice versa.
-- `int` &rarr; `bool`: only if the `int` value is `0` (converted to `false`) or `1` (converted to `true`)
+- `int` &rarr; `bool`: only if the `int` value is `0` (converted to `false`) or `1` (converted to `true`).
 - `int<W>` &rarr; `bit<W>`: preserves all bits unchanged and reinterprets negative
-  values as positive values
-- `bit<W>` &rarr; `int<W>`: preserves all bits unchanged and reinterprets values whose most-significant bit is `1` as negative values
-- `bit<W>` &rarr; `bit<X>`: truncates the value if `W > X`, and otherwise (i.e., if  `W <= X`) pads the value with zero bits.
-- `int<W>` &rarr; `int<X>`: truncates the value if `W > X`, and otherwise (i.e., if `W < X`) extends it with the sign bit.
-- `bit<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result is always non-negative
-- `int<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result may be negative
+  values as positive values. Note that `W` can be an integer or an expression that will evaluate to an integer.
+- `bit<W>` &rarr; `int<W>`: preserves all bits unchanged and reinterprets values whose most-significant bit is `1` as negative values. Note that `W` can be an integer or an expression that will evaluate to an integer.
+- `bit<W>` &rarr; `bit<X>`: truncates the value if `W > X`, and otherwise (i.e., if  `W <= X`) pads the value with zero bits. Note that `W` and `X` can be an integer or an expression that will evaluate to an integer.
+- `int<W>` &rarr; `int<X>`: truncates the value if `W > X`, and otherwise (i.e., if `W < X`) extends it with the sign bit. Note that `W` and `X` can be an integer or an expression that will evaluate to an integer.
+- `bit<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result is always non-negative. Note that `W` can be an integer or an expression that will evaluate to an integer.
+- `int<W>` &rarr; `int`: preserves the value unchanged but converts it to an unlimited-precision integer; the result may be negative. Note that `W` can be an integer or an expression that will evaluate to an integer.
 - `int` &rarr; `bit<W>`: converts the integer value into a sufficiently
   large two's complement bit string to avoid information loss,
   and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow or on conversion of negative value.
+  Note that `W` can be an integer or an expression that will evaluate to an integer.
 - `int` &rarr; `int<W>`: converts the integer value into a
   sufficiently-large two's complement bit string to avoid information
   loss, and then truncates the result to `W` bits. The compiler should
   emit a warning on overflow.
-- `tuple` &rarr; `struct`: converts a tuple with `n` elements to a struct with `n` element. It associates the order of the elements in the list to the order of the elemenets in the struct.
-- `tuple` &rarr; `header`: converts a tuple with `n` elements to a header with `n` element. It associates the order of the elements in the list to the order of the elemenets in the header.
-- `tuple` &rarr; `anonymous header`: converts a tuple with `n` elements to a header with `n` element. It associates the order of the elements in the list to the order of the elemenets in the header. TODO.
+  Note that `W` can be an integer or an expression that will evaluate to an integer.
+- `tuple` &rarr; `struct`: converts a list with `n` elements to a struct with `n` element. It associates the order of the elements in the list to the order of the elemenets in the struct.
+- `tuple` &rarr; `header`: converts a list with `n` elements to a header with `n` element. It associates the order of the elements in the list to the order of the elemenets in the header.
 - casts between two types that are introduced by `typedef` and are equivalent to one of the above combinations.
 - casts from a typedef to the original type and vice versa.
 - casts from a type introduced by `type` to the original type and vice versa.
@@ -3839,7 +3855,8 @@ expression ...
 
 The type of a tuple expression is a tuple type (Section
 [#sec-tuple-types]). Tuple expressions can be assigned to expressions
-of type `tuple`, `struct` or `header`, and can also be
+of type `tuple` in addition to `struct` or `header` since a tuple type
+can be casted to `struct` or `header`. They can also be
 passed as arguments to methods. Tuples may be nested. However, tuple
 expressions are not l-values.
 
@@ -3868,10 +3885,12 @@ struct S {
     bit<32> b;
 }
 const S x = { 10, 20 }; //a = 10, b = 20
+                        // implicit cast of tuple to struct
 ~ End P4Example
 
-A tuple expression can have an explicit structure or header type
-specified, and then it is converted automatically to a
+A tuple expression can be used to initialize a structure or header type,
+in which case it is implicitly casted to a struct or header and its value is
+converted to a
 structure-valued expression (see [#sec-structure-expressions]):
 
 ~ Begin P4Example
@@ -3882,7 +3901,7 @@ struct S {
 
 extern void f<T>(in T data);
 
-f((S){ 10, 20 }); // automatically converted to f((S){a = 10, b = 20});
+f((S){ 10, 20 }); // {10, 20} is converted to {a = 10, b = 20}
 ~ End P4Example
 
 Tuple expressions can also be used to initialize variables whose type
@@ -4151,7 +4170,10 @@ automatically becomes valid:
 header H { bit<32> x; bit<32> y; }
 H h;
 h = { 10, 12 };  // This also makes the header h valid
+                 // implicit cast of int to bit<32>
+                 // implicit cast of tuple to header
 h = { y = 12, x = 10 };  // Same effect as above
+                         // implicit cast of int to bit<32>
 ~ End P4Example
 
 Two headers can be compared for equality (==) or inequality (!=) only
@@ -5119,6 +5141,11 @@ to a value, and finally copies the value into the l-value. Derived
 types (e.g. `structs`) are copied recursively, and all components
 of `header`s are copied, including "validity" bits. Assignment is
 not defined for `extern` values.
+If the type of the right sub-expression
+does not match the type of the left sub-expression, the right
+sub-expression will be implicitly casted to the type of the left
+sub-expression. If such implicit cast is illegal, then the assignment
+is illegal.
 
 ## Empty statement { #sec-empty-stmt }
 

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2175,9 +2175,9 @@ For example, the declaration
 
 ~ Begin P4Example
 enum bit<8> FailingExample {
-  first           = 1,
-  second          = 2,
-  third           = 3,
+  first           = 1, // implicit cast converts 1 to 8w1
+  second          = 2, // implicit cast converts 1 to 8w2
+  third           = 3, // implicit cast converts 1 to 8w3
   unrepresentable = 300
 }
 ~ End P4Example


### PR DESCRIPTION
This PR addresses some of the issues mentioned in #1223. Specifically, it addresses the following:

- Uses consistent terminology to talk about implicit cast
- Adds grammar for casts
- Expands explicit cast enumeration
- Adds comments in some examples where implicit cast occurs
- Adds the recursiveness of casting

Some questions arose while formalizing some of P4 which are related to this PR:
- [x] Should we add record types (or anonymous header types) so that we can explicitly add them to the casting section, instead of dancing around it every time we use record types to initialize a struct or header? Discussed this in the LDWG meeting on March 6th. Not sure if there's a consensus. I marked specific places where having a specific type of structure-value expression is needed. Suggestion: propose the change in a PR. 
- [x] Other than the potential casting of the subtypes of a list, can a list be casted to another type or be the result of a cast? No. At first glance, it seems that the value of a list can only be written using an explicit cast expression, however, I don't think spec defines it as such. It seems that that's just part of the syntax. However, this is similar to the grammar defined for operations on structure-valued expressions, i.e., `'(' typeref ')' expression`, which is basically what a cast is but it's not recognized as a cast. 
- [x] Are there any restrictions for the nesting of generic types? No, this is checked when types are instantiated.