### PR TITLE
Fix and prettify references to compile-time size determination

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3322,7 +3322,7 @@ serialization data type and representation.
 
 Additionally, the size of a serializable enum can be determined at
 compile-time. However, the size of an enum without an
-underlying type cannot be determined at compile-time [#sec-determin].
+underlying type cannot be determined at compile-time (Section [#sec-minsizeinbits]).
 
 ## Operations on `match_kind` types { #sec-match-kind-exprs }
 
@@ -3346,7 +3346,7 @@ The precedence of these operators is similar to C and uses short-circuited
 evaluation where relevant.
 
 Additionally, the size of a boolean can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 P4 does not implicitly cast from bit-strings to Booleans or
 vice versa. As a consequence, a program that is valid in a language like C such as,
@@ -3480,7 +3480,7 @@ Bit-strings also support the following operations:
   In concatenation, the left operand is placed as the most significant bits.
 
 Additionally, the size of a bit-string can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 ## Operations on fixed-width signed integers { #sec-int-ops }
 
@@ -3570,7 +3570,7 @@ The `int<W>` datatype also support the following operations:
   In concatenation, the left operand is placed as the most significant bits.
 
 Additionally, the size of a fixed-width signed integer can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 ## Operations on arbitrary-precision integers { #sec-varint-ops }
 
@@ -3722,7 +3722,7 @@ finding this information in a section dedicated to type `varbit`.
   the packet being constructed.
 
 Additionally, the size of a variable-length bit-string can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 ## Casts { #sec-casts }
 
@@ -4010,7 +4010,7 @@ control c() {
 ~ End P4Example
 
 Additionally, the size of a list can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 ## Operations on sets { #sec-set-exprs }
 
@@ -4152,7 +4152,7 @@ with a tuple expression, as discussed in Section [#sec-tuple-exprs], or
 with a structure-valued expression, as described in
 [#sec-structure-expressions].  Both of these cases must initialize all
 fields of the structure. The size of a struct can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 Two structs can be compared for equality (==) or inequality (!=) only
 if they have the same type and all of their fields can be recursively
@@ -4204,7 +4204,7 @@ h = { y = 12, x = 10 };  // Same effect as above
 ~ End P4Example
 
 Furthermore, the size of a header can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 Two headers can be compared for equality (==) or inequality (!=) only
 if they have the same type.  Two headers are equal if and only if they
@@ -4342,7 +4342,7 @@ void pop_front(int count) {
 ~ End P4Pseudo
 
 Similar to structs and headers, the size of a header stack can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 Two header stacks can be compared for equality (==) or inequality (!=)
 only if they have the same element type and the same length.  Two
@@ -4552,7 +4552,7 @@ parser Tcp_option_parser(packet_in b, out Tcp_option_stack vec) {
 ~End P4Example
 
 Similar to headers, the size of a header union can be determined at
-compile-time [#sec-determin].
+compile-time (Section [#sec-minsizeinbits]).
 
 Two header unions can be compared for equality (==) or inequality (!=)
 if they have the same type.  The unions are equal if and only if all


### PR DESCRIPTION
- Replaced `[#sec-determin]` with `(Section [#sec-determin])` globally
- Also, `sec-determin` doesn't exist. I think it should have been `sec-minsizeinbits`?
