### PR TITLE
Add initialize method to InternetChecksum

### DIFF
--- a/p4-16/psa/examples/psa-example-incremental-checksum.p4
+++ b/p4-16/psa/examples/psa-example-incremental-checksum.p4
@@ -208,14 +208,8 @@ control EgressDeparserImpl(packet_out packet,
             });
         hdr.ipv4.hdrChecksum = ck.get();
         // Update TCP checksum
-        // This clear() call is necessary for correct behavior, since
-        // the same instance 'ck' is reused from above for the same
-        // packet.  If a second InternetChecksum instance other than
-        // 'ck' were used below instead, this clear() call would be
-        // unnecessary.
-        ck.clear();
-        // Subtract the original TCP checksum
-        ck.subtract(hdr.tcp.checksum);
+        // Initialize with the original TCP checksum
+        ck.initialize(hdr.tcp.checksum);
         // Subtract the effect of the original IPv4 source address,
         // which is part of the TCP 'pseudo-header' for the purposes
         // of TCP checksum calculation (see RFC 793), then add the

--- a/p4-16/psa/psa.p4
+++ b/p4-16/psa/psa.p4
@@ -570,6 +570,17 @@ extern InternetChecksum {
   /// 16 bits long.
   void subtract<T>(in T data);
 
+  /// Initialize the InternetChecksum extern object.
+  /// This method prepares the InternetChecksum object to compute an
+  /// incremental checksum (e.g. TCP checksum).
+  /// The primary use case for this method is to initialize the checksum
+  /// computation with the value extracted from the received packet header.
+  /// Calling ck.initizalize(chksum) is algorithmically equivalent to calling
+  /// ck.clear() followed by ck.substract(chksum)
+  /// @param chksum : The initial checksum value, typically extracted from
+  ///                 the packet header.
+  void initialize(in bit<16> chksum);
+
   /// Get checksum for data added (and not removed) since last clear
   @noSideEffects
   bit<16> get();


### PR DESCRIPTION
I would like to propose adding a new method to the `InternetChecksum` extern which would initialize the incremental checksum computation with the initial checksum value extracted from a header.

The motivation behind the method is that currently to achieve this, one needs to call the `subtract` method which may not be obvious to someone not familiar with the exact formula used for computation so a separate method with a more obvious name would be helpful. Another name considered for this method is `preload`.

Implementation will be simple because in compilers that already support PSA's interface, `ck.initialize(chksum);` can be transformed to `ck.clear(); ck.subtract(chksum);`