### PR TITLE
Remove misleading overflow warnings for signed integer literals

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2118,9 +2118,9 @@ types. For additional examples of literals see Section
 | `10`    | Type is `int`, value is 10 |
 | `8w10`  | Type is `bit<8>`, value is 10 |
 | `8s10`  | Type is `int<8>`, value is 10 |
-| `2s3`   | Type is `int<2>`, value is -1 (last 2 bits), overflow warning |
+| `2s3`   | Type is `int<2>`, value is -1 |
 | `1w10`  | Type is `bit<1>`, value is 0 (last bit), overflow warning |
-| `1s1`   | Type is `int<1>`, value is -1, overflow warning |
+| `1s1`   | Type is `int<1>`, value is -1 |
 |---------|--------------------|
 
 ## Derived types { #sec-derived-types }


### PR DESCRIPTION
I would like to propose removing overflow warnings when signed integer literals of explicitly-declared width are specified using positive values with the most significant bit set, i.e. which will be reinterpreted as negative numbers. This is actually the only way negative integer literals of explicitly-declared width can be specified, as per Section 6.3.3.2.

This proposal is accompanied by respective change to the compiler (p4c PR [#4309](https://github.com/p4lang/p4c/pull/4309)).