### PR TITLE
Add annotations on functionDeclaration in grammar

### DIFF
--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -940,7 +940,8 @@ initializer
 
 // BEGIN:functionDeclaration
 functionDeclaration
-    : functionPrototype blockStatement
+    : annotations functionPrototype blockStatement
+    | functionPrototype blockStatement
     ;
 // END:functionDeclaration
 


### PR DESCRIPTION
Trivial addition to the grammar to match with p4c [#4452](https://github.com/p4lang/p4c/pull/4452)

The spec text says that annotations are allowed on "types, fields, variables, etc.", so doesn't explicitly mention functions (but also doesn't mention actions, tables, externs, extern instances, block statements, match keys, and probably also other things that allow annotations currently).

The grammar is copied directly from p4c, so has the oddness that some places use `optAnnotations` and other places (such as this) use duplicate rules with and without `annotations`.  It might make sense to use `optAnnotations` everywhere in the spec grammar -- this is not done in p4c, since doing so is not LR(1) (requires more lookahead) when the construction requires more lookahead to know the difference between a *declaration* (which allows annotations) and a *statement* (which does not).  We could also allow annotations on statements, though it is not clear how useful that would be.