### PR TITLE
Allow parentheses in lvalues

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1457,12 +1457,7 @@ following expressions are legal l-values:
 ~ Begin P4Grammar
 [INCLUDE=grammar.mdk:prefixedNonTypeName]
 
-lvalue
-    : prefixedNonTypeName
-    | lvalue "." member
-    | lvalue "[" expression "]"
-    | lvalue "[" expression ":" expression "]"
-    ;
+[INCLUDE=grammar.mdk:lvalue]
 ~ End P4Grammar
 
 - Identifiers of a base or derived type.

--- a/p4-16/spec/grammar.mdk
+++ b/p4-16/spec/grammar.mdk
@@ -1002,6 +1002,7 @@ lvalue
     | lvalue "." member
     | lvalue "[" expression "]"
     | lvalue "[" expression ":" expression "]"
+    | "(" lvalue ")"
     ;
 // END:lvalue
 


### PR DESCRIPTION
This pull request addresses the issue #1273.

Added the definition allowing parentheses around lvalues to the grammar, similar to what was done in p4lang/p4c#4530.

In addition to that performed a minor cleanup, replacing the (copied) grammar code with the proper INCLUDE.