### PR TITLE
Add explanation on passing directionless, extern object argument

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -1507,6 +1507,7 @@ Each parameter may be labeled with a direction:
     function, a directionless parameter means that the value supplied
     as an argument in a call must be a compile-time known value
     (see Section [#sec-ct-constants]).
+    - A directionless parameter of extern object type is passed by reference.
   - For an action, a directionless parameter indicates that it is
     "action data".  See Section [#sec-actions] for the meaning of
     action data, but its meaning includes the following possibilities:


### PR DESCRIPTION
I propose adding some clarifications to the spec, discussing how directionless, extern objects are passed to a control/parser. (#1276)

In the below parser type declaration, the first parameter, `packet_in b` is an directionless extern object.

```p4
parser Top(packet_in b, out Parsed_headers headers) {
```

Spec section **6.8. Calling convention: call by copy in/copy out** discusses the calling convention on directionless parameter as follows:

> The meaning of parameters with no direction depends upon the kind of entity the parameter is for:
> For anything other than an action, e.g. a control, parser, or function, a directionless parameter means that the value supplied as an argument in a call must be a compile-time known value (see Section [18.1](https://staging.p4.org/p4-spec/docs/P4-16-v1.2.4.html?_ga=2.183793696.727750878.1700665192-205673382.1700549788&_gl=1*1j2krm1*_ga*MjA1NjczMzgyLjE3MDA1NDk3ODg.*_ga_FW0Q4274RH*MTcwMDY2NTE5Mi4yLjEuMTcwMDY2NTIwMi4wLjAuMA..*_ga_VXXZD2250K*MTcwMDY2NTE5Mi4yLjEuMTcwMDY2NTIwMi4wLjAuMA..#sec-ct-constants)).
> For an action, a directionless parameter indicates that it is “action data”. See Section [14.1](https://staging.p4.org/p4-spec/docs/P4-16-v1.2.4.html?_ga=2.183793696.727750878.1700665192-205673382.1700549788&_gl=1*1j2krm1*_ga*MjA1NjczMzgyLjE3MDA1NDk3ODg.*_ga_FW0Q4274RH*MTcwMDY2NTE5Mi4yLjEuMTcwMDY2NTIwMi4wLjAuMA..*_ga_VXXZD2250K*MTcwMDY2NTE5Mi4yLjEuMTcwMDY2NTIwMi4wLjAuMA..#sec-actions) for the meaning of action data, but its meaning includes the following possibilities:
> The parameter's value is provided in the P4 program. In this case, the parameter behaves as if the direction were in. Such an argument expression need not be a compile-time known value.
> The parameter's value is provided by the control plane software when an entry is added to a table that uses that action. See Section [14.1](https://staging.p4.org/p4-spec/docs/P4-16-v1.2.4.html?_ga=2.183793696.727750878.1700665192-205673382.1700549788&_gl=1*1j2krm1*_ga*MjA1NjczMzgyLjE3MDA1NDk3ODg.*_ga_FW0Q4274RH*MTcwMDY2NTE5Mi4yLjEuMTcwMDY2NTIwMi4wLjAuMA..*_ga_VXXZD2250K*MTcwMDY2NTE5Mi4yLjEuMTcwMDY2NTIwMi4wLjAuMA..#sec-actions).

Yet, it does not discuss how the parameter `packet_in b` should actually be passed to the parser block.

Given that the `packet_in` object is stateful (+ instantiated by the target), it seems reasonable to assume that passing it by reference would be the appropriate approach, rather than copying the entire object.

I suggest that the specification clarify this point by providing guidance on how directionless extern parameters should be passed to parsers, controls, or functions.