### PR TITLE
Madoko requires blank line before first element of a list

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3340,6 +3340,7 @@ const bool same = exact == fuzzy;  // always 'false'
 ## Expressions on Booleans { #sec-bool-exprs }
 
 The following operations are provided on Boolean expressions:
+
 - "And", denoted by `&&`
 - "Or", denoted by `||`
 - Negation, denoted by `!`


### PR DESCRIPTION
Otherwise it does not format it as a bulleted list.