### PR TITLE
Clarifications suggested by Chris Dodd

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2102,11 +2102,11 @@ parameters.
 
 The types of integer literals are as follows:
 
-- An integer has type `int`.
-- A non-negative integer prefixed with an integer width `N` and the
-  character `w` has type `bit<N>`.
-- An integer prefixed with an integer width `N` and the character `s`
-  has type `int<N>`.
+- An integer with no type prefix has type `int`.
+- A non-negative integer prefixed with an integer width `W` and the
+  character `w` has type `bit<W>`.
+- An integer prefixed with an integer width `W` and the character `s`
+  has type `int<W>`.
 
 The table below shows several examples of integer literals and their
 types. For additional examples of literals see Section
@@ -2200,8 +2200,8 @@ allowed to have fields with such `enum` types. This requires the programmer prov
 an associated integer value for each symbolic entry in the enumeration.
 The symbol `typeRef` in the grammar above must be one of the following types:
 
-- an unsigned integer, i.e. `bit<W>` for some compile-time known value `W`.
-- a signed integer, i.e. `int<W>` for some compile-time known value `W`.
+- an unsigned integer, i.e. `bit<W>` for some local compile-time known value `W`.
+- a signed integer, i.e. `int<W>` for some local compile-time known value `W`.
 - a type name declared via `typedef`, where the base type of that type is either
 one of the types listed above, or another `typedef` name that meets these conditions.
 For example, the declaration


### PR DESCRIPTION
This PR implements some good, but late-breaking suggestions on PR #1213 made by @ChrisDodd.

As a driveby: change a few occurrences of `bit<N>` and `int<N>` to `bit<W>` and `int<W>` respectively, for consistency with the rest of the specification.