### PR TITLE
Specify valid type alias rule for string type

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -2570,6 +2570,7 @@ The table below lists all types that may appear as base types in a
 | `varbit<W>`      | allowed            | error           |
 | `int`            | allowed            | error           |
 | `void`           | error              | error           |
+| `string`         | allowed            | error           |
 | `error`          | allowed            | error           |
 | `match_kind`     | error              | error           |
 | `bool`           | allowed            | allowed         |


### PR DESCRIPTION
Proposing clarification for under-specified case, whether it is valid when `string` is aliased by either `typedef` or `type`. (#1293)

I expect that new type declaration (`type`) does not allow string type, and such is allowed for `typedef`. Checking with the p4c compiler, it currently allows string to be aliased by typedef, e.g.,` typedef string string_t;` typechecks.