### PR TITLE
Minor typo fix in section 8.11.2 Implicit casts

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -3823,7 +3823,7 @@ the compiler will add implicit casts as follows:
 - `E.a ++ 8w0` becomes `(bit<8>)E.a ++ 8w0`
 
 The compiler also adds implicit casts when types of different
-expressions need to ``match''; for example, as described in Section
+expressions need to `match`; for example, as described in Section
 [#sec-select], since select labels are compared against the selected
 expression, the compiler will insert implicit casts for the select
 labels when they have `int` types.  Similarly, when assigning a


### PR DESCRIPTION
Fixes unmatched backticks (`) :)