### PR TITLE
Identifiers declared as constants are local compile-time known

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -5115,7 +5115,7 @@ struct Version {
 const Version version = { 32w0, 32w0 };
 ~ End P4Example
 
-The `initializer` expression must be a compile-time known value.
+The `initializer` expression must be a local compile-time known value.
 
 ## Variables { #sec-variables }
 
@@ -7739,6 +7739,7 @@ _local compile-time known values_ respectively.
 The following are local compile-time known values:
 
 - Integer literals, Boolean literals, and string literals.
+- Identifiers declared as constants using the `const` keyword.
 - Identifiers declared in an `error`, `enum`, or `match_kind` declaration.
 - The `default` identifier.
 - The `size` field of a value with type header stack.
@@ -7757,7 +7758,6 @@ The following are compile-time known values:
 
 - All local compile-time known values.
 - Constructor parameters (i.e., the declared parameters for a `parser`, `control`, etc.)
-- Identifiers declared as constants using the `const` keyword.
 - Tuple expression where all components are compile-time known values.
 - Expressions evaluating to a list type, where all elements are compile-time known values.
 - Structure-valued expressions, where all fields are compile-time known values.


### PR DESCRIPTION
Following the discussion #1305, this PR clarifies that identifiers declared as constants with the `const` keyword is local compile-time known instead of compile-time known.

Also, I made a corresponding change in the constant declaration section (11.1) that the initializer for a constant should be local compile-time known.