### PR TITLE
Change code example for sec-type-variable-operations

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4799,7 +4799,7 @@ bool b2 = x == y;  // no cast needed
 
 ## Operations on types that are type variables { #sec-type-variable-operations }
 
-Because functions, methods, control, and parsers can be generic,
+Because functions and methods can be generic,
 they offer the possibility of declaring values with types that
 are type variables:
 
@@ -4809,8 +4809,8 @@ void f<T>() {
 }
 ~ End P4Example
 
-The type of such objects is not known until the control is
-instantiated with specific type arguments.
+The type of such objects is not known until the function is
+specialized with specific type arguments.
 
 Currently the only operations that are available for such values are
 assignment (explicit through `=`, or implicit, through argument passing).

--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -4804,10 +4804,8 @@ they offer the possibility of declaring values with types that
 are type variables:
 
 ~ Begin P4Example
-control C<T>() {
-    apply {
-        T x;  // the type of x is T, a type variable
-    }
+void f<T>() {
+   T x; // the type of x is T, a type variable
 }
 ~ End P4Example
 


### PR DESCRIPTION
Following the discussion #1295, this changes the code example of sec-type-variable-operations such that declaration of a local of a variable type happens inside a generic function, not a generic control.