### PR TITLE
Remove redundant explanation on compile-time list evaluation

### DIFF
--- a/p4-16/spec/P4-16-spec.mdk
+++ b/p4-16/spec/P4-16-spec.mdk
@@ -7761,7 +7761,6 @@ The following are compile-time known values:
 - Tuple expression where all components are compile-time known values.
 - Expressions evaluating to a list type, where all elements are compile-time known values.
 - Structure-valued expressions, where all fields are compile-time known values.
-- Expressions evaluating to a list type, where all elements are compile-time known values.
 - Legal casts applied to compile-time known values.
 - The following expressions (`+`, `-`, `|+|`, `|-|`, `*`, `/ `, `%`, `cast`, `!`, `&`, `|`, `^`, `&&`, `||`, `<< `, `>> `, `~`, `/`, `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`) when their operands are all compile-time known values.
 - Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`, `e.maxSizeInBits()` and `e.maxSizeInBytes()` where the the type of `e` is generic.


### PR DESCRIPTION
This removes a redundant line in section 18.1.