### PR TITLE
embed images in html docs

### DIFF
--- a/p4-16/psa/PSA.adoc
+++ b/p4-16/psa/PSA.adoc
@@ -17,6 +17,7 @@
 :stylesdir: resources/theme/
 :stylesheet: p4-stylesheet.css
 :source-highlighter: rouge
+:data-uri:
 
 [abstract]
 .Abstract

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -3,6 +3,7 @@
 :revdate: {docdate}
 :revnumber: v1.2.5
 :imagesdir: resources/figs
+:data-uri:
 :font-size: 10
 :sectnums: 5
 :sectnumlevels: 5


### PR DESCRIPTION
This PR fixes the issue of [images not showing up](https://p4.org/p4-spec/docs/p4-16-working-draft.html) in specs built from Asciidocs in CI. The solution is to use the `:data-uri:` directive to embed images as data in the HTML.