### PR TITLE
Allow implicit cast for directionless args

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -4880,8 +4880,8 @@ f(y = ya, x = xa);  // match arguments by name in any order
 
 The calling convention is copy-in/copy-out (<<sec-calling-convention>>).  For generic functions the type arguments
 can be explicitly specified in the function call. The compiler only
-inserts implicit casts for direction `in` or directionless arguments to methods or
-functions as described in <<sec-casts>>.  The types for all
+inserts implicit casts for direction `in` or directionless arguments to methods,
+functions, or constructors as described in <<sec-casts>>. The types for all
 other arguments must match the parameter types exactly.
 
 The result returned by a function call is discarded when the function

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -4880,7 +4880,7 @@ f(y = ya, x = xa);  // match arguments by name in any order
 
 The calling convention is copy-in/copy-out (<<sec-calling-convention>>).  For generic functions the type arguments
 can be explicitly specified in the function call. The compiler only
-inserts implicit casts for direction `in` arguments to methods or
+inserts implicit casts for direction `in` or directionless arguments to methods or
 functions as described in <<sec-casts>>.  The types for all
 other arguments must match the parameter types exactly.
 


### PR DESCRIPTION
I would like to propose allowing implicit cast for directionless method / function / constructor arguments, following the discussion made in #1312.

Regarding it, the current spec section 8.20 mentions that:

> The calling convention is copy-in/copy-out (Section [6.8](https://p4.org/p4-spec/docs/p4-16-working-draft.html#sec-calling-convention)). For generic functions the type arguments can be explicitly specified in the function call. **The compiler only inserts implicit casts for direction in arguments to methods or functions** as described in Section [8.11](https://p4.org/p4-spec/docs/p4-16-working-draft.html#sec-casts). The types for all other arguments must match the parameter types exactly.

So as per the spec, we *cannot* apply implicit cast for directionless **method / function / constructor** arguments.

As a side note, directionless **action** arguments *can* be implicitly cast as per the spec since it mentions the following in section 6.8.1.

> Actions can also be explicitly invoked using function call syntax, either from a control block or from another action. In this case, values for all action parameters must be supplied explicitly, including values for the directionless parameters. **The directionless parameters in this case behave like in parameters.**

So, like the case for action, I am proposing to allow implicit cast for directionless method / function / constructor arguments.

I believe it better reflects the use cases in the p4c test suite. Below is a drop-down list of tests that expect such a feature.
<details>
<summary>List of tests</summary>

* extern-funcs-bmv2.p4
* extern2.p4
* gauntlet_extern_arguments_2.p4
* gauntlet_hdr_in_value-bmv2.p4
* issue1001-1-bmv2.p4
* issue1001-bmv2.p4
* issue1043-bmv2.p4
* issue1334.p4
* issue1642-bmv2.p4
* issue1653-bmv2.p4
* issue1653-complex-bmv2.p4
* issue1660-bmv2.p4
* issue1765-1-bmv2.p4
* issue2648.p4
* issue3246-1.p4
* issue383-bmv2.p4
* issue562-bmv2.p4
* issue933-1.p4
* named-arg1.p4
* v1model-special-ops-bmv2.p4
* bfd_offload.p4
* calc-ebpf.p4
* constructor_cast.p4
* issue1006.p4
* issue1097-2-bmv2.p4
* issue1097-bmv2.p4
* issue1814-1-bmv2.p4
* issue1814-bmv2.p4
* issue1958.p4
* issue2844-enum.p4
* issue298-bmv2.p4
* issue4288.p4
* issue754.p4
* list7.p4
* pr1363.p4
* psa-action-profile1.p4
* psa-action-profile3.p4
* psa-action-profile4.p4
* psa-basic-counter-bmv2.p4
* psa-counter1.p4
* psa-counter2.p4
* psa-counter3.p4
* psa-custom-type-counter-index.p4
* psa-end-of-ingress-test-bmv2.p4
* psa-example-dpdk-byte-alignment_1.p4
* psa-example-dpdk-byte-alignment_2.p4
* psa-example-dpdk-byte-alignment_3.p4
* psa-example-dpdk-byte-alignment_5.p4
* psa-example-dpdk-byte-alignment_6.p4
* psa-example-dpdk-byte-alignment_7.p4
* psa-example-dpdk-byte-alignment_8.p4
* psa-example-dpdk-byte-alignment_9.p4
* pse-example-dpdk-counter.p4
* psa-example-dpdk-externs.p4
* psa-example-dpdk-meter-execute-err.p4
* psa-example-dpdk-meter.p4
* psa-example-dpdk-meter1.p4
* psa-example-dpdk-varbit-bmv2.p4
* psa-meter1.p4
* psa-meter3.p4
* psa-meter7-bmv2.p4
* psa-random.p4
* psa-register-complex-bmv2.p4
* psa-register-read-write-2-bmv2.p4
* psa-register-read-write-bmv2.p4
* psa-register1.p4
* psa-register2.p4
* psa-register3.p4
* rcp.p4
* rcp1.p4
* register-serenum-bmv2.p4
* simple-firewall_ubpf.p4
* unused-counter-bmv2.p4
* value-sets.p4
</details>