### PR TITLE
Specify compile-time evaluation of field and index accesses

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -8102,6 +8102,8 @@ The following are local compile-time known values:
 - Structure-valued expressions, where all fields are local compile-time known values.
 - Expressions evaluating to a list type, where all elements are local compile-time known values.
 - Legal casts applied to local compile-time known values.
+- Indexing a local compile-time known stack or tuple value with a local compile-time known index.
+- Accessing a field of a local compile-time known struct, header, or header union value.
 - The following expressions (`+`, `-`, `|+|`, `|-|`, `*`, `/ `, `%`, `!`, `&`, `|`, `^`, `&&`, `||`, `<< `, `>>`, `~`, `/`, `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`) when their operands are all local compile-time known values.
 - Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`, `e.maxSizeInBits()` and `e.maxSizeInBytes()` where the type of `e` is not generic.
 
@@ -8114,6 +8116,8 @@ The following are compile-time known values:
 - Structure-valued expressions, where all fields are compile-time known values.
 - Expressions evaluating to a list type, where all elements are compile-time known values.
 - Legal casts applied to compile-time known values.
+- Indexing a compile-time known stack or tuple value with a compile-time known index.
+- Accessing a field of a compile-time known struct, header, or header union value.
 - The following expressions (`+`, `-`, `|+|`, `|-|`, `*`, `/ `, `%`, `cast`, `!`, `&`, `|`, `^`, `&&`, `||`, `<< `, `>> `, `~`, `/`, `>`, `<`, `==`, `!=`, `<=`, `>=`, `++`, `[:]`, `?:`) when their operands are all compile-time known values.
 - Expressions of the form `e.minSizeInBits()`, `e.minSizeInBytes()`, `e.maxSizeInBits()` and `e.maxSizeInBytes()` where the the type of `e` is generic.
 


### PR DESCRIPTION
This adds to the list of (local) compile-time known values in section 18.1. (#1323)

In summary, for index access,

* `e1[e2]` is local compile-time known if both `e1` and `e2` are local compile-time known.
* `e1[e2]` is compile-time known if both `e1` and `e2` are compile-time known.
* Note that `e1` should be of a header stack or tuple type.

And for field access,

* `e.x` is local compile-time known if `e` is local compile-time known.
* `e.x` is compile-time known if `e` is compile-time known.
* Note that `e` should be of a struct, header, or header union type.