### PR TITLE
Add type nesting rules for extern, parser, control, and package types

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -2560,6 +2560,13 @@ arbitrary-precision integer, without a width specified.
 
 | `list types`         | error     | error   |  error   | allowed | error
 
+| `extern types`       | error     | error   |  error   | error   | error
+
+| `parser types`       | error     | error   |  error   | error   | error
+
+| `control types`      | error     | error   |  error   | error   | error
+
+| `package types`      | error     | error   |  error   | error   | error
 |===
 
 [1] An `enum` type used as a field in a `header` must specify a
@@ -2607,19 +2614,27 @@ The table below lists all types that may appear as base types in a
 
 | `bool`              | allowed            | allowed
 
-| enumeration types   | allowed            | error
+| `enumeration types`   | allowed            | error
 
-| header types        | allowed            | error
+| `header types`        | allowed            | error
 
-| header stacks       | allowed            | error
+| `header stacks`       | allowed            | error
 
-| header unions       | allowed            | error
+| `header unions`       | allowed            | error
 
-| struct types        | allowed            | error
+| `struct types`        | allowed            | error
 
-| tuple types         | allowed            | error
+| `tuple types`         | allowed            | error
 
-| list types          | allowed            | error
+| `list types`          | allowed            | error
+
+| `extern types`        | allowed            | error
+
+| `parser types`        | allowed            | error
+
+| `control types`       | allowed            | error
+
+| `package types`       | allowed            | error
 
 | a `typedef` name    | allowed            | allowed [3]
 


### PR DESCRIPTION
I would like to propose a change to the spec following the discussion made in #1324.
This adds the cases for extern / parser / control / package types for the type nesting rule defined in section 7.2.8.

In summary,
* It *disallows* extern / parser / control / package types from being nested inside a header / header union / struct / tuple / list / header stack.
* It *allows* extern / parser / control / package to be aliased by `typedef`, but *disallows* for `type`.