### PR TITLE
Remove redundant explanation on compile-time list evaluation

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -8110,7 +8110,6 @@ The following are compile-time known values:
 - All local compile-time known values.
 - Constructor parameters (i.e., the declared parameters for a `parser`, `control`, etc.)
 - Tuple expression where all components are compile-time known values.
-- Expressions evaluating to a list type, where all elements are compile-time known values.
 - Structure-valued expressions, where all fields are compile-time known values.
 - Expressions evaluating to a list type, where all elements are compile-time known values.
 - Legal casts applied to compile-time known values.


### PR DESCRIPTION
This removes a redundant line in section 18.1.