### PR TITLE
Change code example for sec-type-variable-operations

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -4973,21 +4973,19 @@ bool b2 = x == y;  // no cast needed
 [#sec-type-variable-operations]
 === Operations on types that are type variables
 
-Because functions, methods, control, and parsers can be generic,
+Because functions and methods can be generic,
 they offer the possibility of declaring values with types that
 are type variables:
 
 [source,p4]
 ----
-control C<T>() {
-    apply {
-        T x;  // the type of x is T, a type variable
-    }
+void f<T>() {
+   T x; // the type of x is T, a type variable
 }
 ----
 
-The type of such objects is not known until the control is
-instantiated with specific type arguments.
+The type of such objects is not known until the function is
+specialized with specific type arguments.
 
 Currently the only operations that are available for such values are
 assignment (explicit through `=`, or implicit, through argument passing).


### PR DESCRIPTION
Following the discussion https://github.com/p4lang/p4-spec/issues/1295, this changes the code example of sec-type-variable-operations such that declaration of a local of a variable type happens inside a generic function, not a generic control.