### PR TITLE
Specify that value_set's size is compile-time known

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -6565,8 +6565,8 @@ include::grammar.adoc[tag=valueSetDeclaration]
 ----
 
 Parser Value Sets support a `size` argument to provide hints to the compiler to
-reserve hardware resources to implement the value set. For example, this parser
-value set:
+reserve hardware resources to implement the value set. Thus, the `size` argument
+must be a compile-time known value. For example, this parser value set:
 
 [source,p4]
 ----


### PR DESCRIPTION
Following the discussion #1347, this specifies that the `size` argument of a `value_set` must be a compile-time known value.

Although the spec already implies it by mentioning:

> Parser Value Sets support a size argument to provide hints to the compiler to reserve hardware resources to implement the value set.

This revision makes it more explicit.