### PR TITLE
Revise general explanation on type casting

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -3842,9 +3842,10 @@ Additionally, the maximum size of a variable-length bit-string can be determined
 === Casts
 
 P4 provides a limited set of casts between types. A cast is written
-`(t) e`, where `t` is a type and `e` is an expression. Casts are only
-permitted on base types and derived types introduced by `typedef`, `type`, and `enum`.
-While this design is arguably more onerous for programmers, it has several benefits:
+`(t) e`, where `t` is a type and `e` is an expression. Casts are only permitted in
+cases as defined in section <<sec-explicit-casts>> for explicit casts and
+section <<sec-implicit-casts>> for implicit casts. While this design is arguably
+more onerous for programmers, it has several benefits:
 
 * It makes user intent unambiguous.
 * It makes the costs associated with converting numeric values
@@ -3853,6 +3854,7 @@ While this design is arguably more onerous for programmers, it has several benef
 * It reduces the number of cases that have to be considered in the P4
   specification. Some targets may not support all casts.
 
+[#sec-explicit-casts]
 ==== Explicit casts
 
 The following casts are legal in P4:


### PR DESCRIPTION
Following the discussion made at #1351, this PR revises the general explanation on type casting given in section *8.11. Casts** to the following:

```plaintext
;; Before

P4 provides a limited set of casts between types. A cast is written
`(t) e`, where `t` is a type and `e` is an expression. Casts are only
permitted on base types and derived types introduced by `typedef`, `type`, and `enum`.
While this design is arguably more onerous for programmers, it has several benefits:
```

```plaintext
;; After

P4 provides a limited set of casts between types. A cast is written
`(t) e`, where `t` is a type and `e` is an expression. Casts are only permitted in
cases as defined in section <<sec-explicit-casts>> for explicit casts and
section <<sec-implicit-casts>> for implicit casts. While this design is arguably
more onerous for programmers, it has several benefits:
```

Rather than stating "Casts are only permitted on base types and derived types introduced by `typedef`, `type`, and `enum`." (which is quite inaccurate), it puts forward references to the following subsections. Because:
* Not all base types can be casted (e.g., `void`, `error`, `match_kind`, and `string`)
* Derived types, such as `struct` and `header` can be casted, e.g., at initialization.