### PR TITLE
Clarify instantiation of objects with abstract methods

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5415,10 +5415,14 @@ include::grammar.adoc[tag=objDeclarations]
 include::grammar.adoc[tag=objDeclaration]
 ----
 
+Abstract methods must use the same parameter names as those declared
+in the extern object declaration. This avoids ambiguity about
+which abstract method is being implemented.
+
 The abstract methods can only use the supplied arguments or refer to
-values that are in the top-level scope.  When calling another method
-of the same instance the `this` keyword is used to indicate the
-current object instance:
+values that are in the initializer block or the top-level scope. 
+When calling another method of the same instance the `this` keyword is
+used to indicate the current object instance:
 
 [source,p4]
 ----

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5415,13 +5415,13 @@ include::grammar.adoc[tag=objDeclarations]
 include::grammar.adoc[tag=objDeclaration]
 ----
 
-Abstract methods must use the same number of parameters, and the same
-parameter directions as those declared in the extern object declaration.
+Abstract method implementations must use the same number of parameters, and
+the same parameter directions as those declared in the extern object declaration.
 Note that overloading of abstract methods is not allowed, thus an
 implementation could be matched to a declaration only with the method name.
 
 The abstract methods can only use the supplied arguments or refer to
-values that are in the initializer block or the top-level scope. 
+values that are in the same initializer block or the top-level scope. 
 When calling another method of the same instance the `this` keyword is
 used to indicate the current object instance:
 

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -2765,7 +2765,7 @@ either by the number of arguments or by the names of the arguments,
 when calls are specifying argument names.  Argument type information
 is not used in disambiguating calls.
 
-Notice that overloading of parsers, controls, or packages is not allowed:
+Notice that overloading of abstract methods, parsers, controls, or packages is not allowed:
 
 [source,p4]
 ----
@@ -5415,9 +5415,10 @@ include::grammar.adoc[tag=objDeclarations]
 include::grammar.adoc[tag=objDeclaration]
 ----
 
-Abstract methods must use the same parameter names as those declared
-in the extern object declaration. This avoids ambiguity about
-which abstract method is being implemented.
+Abstract methods must use the same number of parameters, and the same
+parameter directions as those declared in the extern object declaration.
+Note that overloading of abstract methods is not allowed, thus an
+implementation could be matched to a declaration only with the method name.
 
 The abstract methods can only use the supplied arguments or refer to
 values that are in the initializer block or the top-level scope. 


### PR DESCRIPTION
Following #1346, this PR adds more rules to the semantics of abstract method initialization.

**First**, it *restricts* that the abstract method being implemented, must have the same parameter names as declared in the object declaration.

This is to (i) disambiguate what abstract method is being implemented, and (ii) provide a clear interface for users.

For example, one may define an extern object with overloaded abstract methods, as follows.

```p4
extern Virtual {
    Virtual();
    abstract bit<32> g(inout bit<32> x); // (1)
    abstract bit<32> g(inout bit<32> y); // (2)
}
```

And in the instantiation site,

```p4
Virtual() virt = {
    bit<32> g(inout bit<32> z) { return x - 1; } // (a)
    bit<32> g(inout bit<32> w) { return x + 1; } // (b)
};
```

*Without* a restriction on matching parameter names, it is unclear whether (a) implements (1) or (2), and (b) implements (1) or (2).

This can further cause confusion when invoking the abstract methods. P4 defines overload resolution via parameter names. If we were to allow such a program, then a user would have to invoke `virt.g(z = 32w42);` and `vir.g(w = 32w42);`, while the extern object declaration suggests that it should be callable by `virt.g(x = 32w42);` or `virt.g(y = 32w42);` instead. i.e., there is a gap between the interface defined in the extern object declaration and what is actually implemented.

The consequences of adding this restriction to the spec would be: [virtual.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/virtual.p4), [issue2175-1.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue2175-1.p4), [issue2175-3.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue2175-3.p4), and [issue2175-4.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue2175-4.p4) in the p4c test suite would have to be rejected by the frontend.

**Second**, it adds the initializer block to the scope of abstract method.

When implementing an abstract method, the scope is limited to the supplied arguments or values that are in the top-level scope.

But this overlooks the case where an instantiation declaration is used inside an object initializer block. Instantiation declaration may be used inside an object initializer block, which is used by program [virtual2.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/virtual2.p4).

```plaintext
objDeclaration
    : functionDeclaration
    | instantiation
    ;
```

```p4
extern Virtual {
    Virtual();
    void run(in bit<16> ix);
    @synchronous(run) abstract bit<16> f(in bit<16> ix);
}
extern State {
    State(int<16> size);
    bit<16> get(in bit<16> index);
}
...
Virtual() cntr = {
    State(16s1024) state;
    bit<16> f(in bit<16> ix) {
        return state.get(ix);
    }
};
```

Notice that `f` uses `state` in its implementation.

Strictly applying what is written in the spec, the program should not be accepted, since `f` refers to `state` that is neither in the top-level scope or the parameter list. i.e., the current spec *syntactically allows* instantiation inside object initializer but *semantically disallows* any way to refer to the instantiated instance.

So this PR adds the object initializer block to the scope as well.