### PR TITLE
Relax runtime and compile-time callsite restrictions

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -9553,9 +9553,9 @@ One way that an extern can be called from the top level of a parser or
 control is in an initializer expression for a declared variable,
 e.g. `bit<32> x = rand.get();`.
 
-[.center,cols="3,^2,^2,^2,^2,^2,^2",width=90%]
+[.center,cols="3,^2,^2,^2,^2,^2,^2,^2",width=90%]
 |===
-| This type 6+^| can be called at run time from this place in a P4 program
+| This type 7+^| can be called at run time from this place in a P4 program
 
 |             .>| top level .>| parser state .>| control apply block .>| top level within a parser or control .>| action .>| extern .>| function
 

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -9490,13 +9490,13 @@ program, but constants may.
 
 |             | top level | package | parser  | control | extern | function
 
-| package     | yes       |  no     | no      | no      |  no    |  no
+| package     | yes       |  yes    | no      | no      |  no    |  no
 
-| parser      |  no       |  no     | yes     | no      |  no    |  no
+| parser      |  no       |  yes    | yes     | no      |  no    |  no
 
-| control     |  no       |  no     | no      | yes     |  no    |  no
+| control     |  no       |  yes    | no      | yes     |  no    |  no
 
-| extern      | yes       |  no     | yes     | yes     |  no    |  no
+| extern      | yes       |  yes    | yes     | yes     |  no    |  no
 
 | function    | yes       |  no     | no      | no      |  no    |  no
 
@@ -9525,7 +9525,7 @@ extern functions), actions, and functions.
 
 | control     |  no       |  no     | no      | no      |  no
 
-| extern      | yes       | yes     | yes     | no      |  no
+| extern      |  yes      | yes     | yes     | no      |  no
 
 | table       |  no       |  no     | no      | no      |  no
 
@@ -9547,7 +9547,7 @@ The next table lists restrictions on what kinds of calls can be made
 from which places in a P4 program.  Calling a parser, control, or
 table means invoking its `apply()` method. Calling a value-set means using it
 in a select expression. The row for `extern` describes where extern method
-calls can be made from.
+or function calls can be made from.
 
 One way that an extern can be called from the top level of a parser or
 control is in an initializer expression for a declared variable,
@@ -9557,25 +9557,25 @@ e.g. `bit<32> x = rand.get();`.
 |===
 | This type 6+^| can be called at run time from this place in a P4 program
 
-|             .>| parser state .>| control apply block .>| parser or top level .>| action .>| extern .>| function
+|             .>| top level .>| parser state .>| control apply block .>| top level within a parser or control.>| action .>| extern .>| function
 
-| package     | N/A       | N/A     | N/A       | N/A     | N/A    | N/A
+| package     | N/A 	      | N/A       | N/A     | N/A       | N/A     | N/A    | N/A
 
-| parser      | yes       |  no     | no        | no      | no     | no
+| parser      | no            | yes       |  no     | no        | no      | no     | no
 
-| control     |  no       | yes     | no        | no      | no     | no
+| control     | no            |  no       | yes     | no        | no      | no     | no
 
-| extern      | yes       | yes     | yes       | yes     | no     | no
+| extern      | yes           | yes       | yes     | yes       | yes     | no     | yes
 
-| table       |  no       | yes     | no        | no      | no     | no
+| table       | no            |  no       | yes     | no        | no      | no     | no
 
-| value-set   | yes       | no      | no        | no      | no     | no
+| value-set   | no            | yes       | no      | no        | no      | no     | no
 
-| action      |  no       | yes     | no        | yes     | no     | no
+| action      | no            |  no       | yes     | no        | yes     | no     | no
 
-| function    | yes       | yes     | no        | yes     | no     | yes
+| function    | yes           | yes       | yes     | yes        | yes     | no     | yes
 
-| value types | N/A       | N/A     | N/A       | N/A     | N/A    | N/A
+| value types | N/A           | N/A       | N/A     | N/A       | N/A     | N/A    | N/A
 
 |===
 

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -9557,7 +9557,7 @@ e.g. `bit<32> x = rand.get();`.
 |===
 | This type 6+^| can be called at run time from this place in a P4 program
 
-|             .>| top level .>| parser state .>| control apply block .>| top level within a parser or control.>| action .>| extern .>| function
+|             .>| top level .>| parser state .>| control apply block .>| top level within a parser or control .>| action .>| extern .>| function
 
 | package     | N/A 	      | N/A       | N/A     | N/A       | N/A     | N/A    | N/A
 

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -9547,11 +9547,15 @@ The next table lists restrictions on what kinds of calls can be made
 from which places in a P4 program.  Calling a parser, control, or
 table means invoking its `apply()` method. Calling a value-set means using it
 in a select expression. The row for `extern` describes where extern method
-or function calls can be made from.
+or extern function calls can be made from. The row for `function` describes
+where calls to functions, but not extern functions, can be made from.
 
 One way that an extern can be called from the top level of a parser or
 control is in an initializer expression for a declared variable,
-e.g. `bit<32> x = rand.get();`.
+e.g. `bit<32> x = rand.get();`. Here, the top level of a parser or control
+means either within a parser declaration, but outside of any of its parser
+state declarations, or within a control declaration, but outside its
+`apply { ... }` block.
 
 [.center,cols="3,^2,^2,^2,^2,^2,^2,^2",width=90%]
 |===
@@ -9573,11 +9577,13 @@ e.g. `bit<32> x = rand.get();`.
 
 | action      | no            |  no       | yes     | no        | yes     | no     | no
 
-| function    | yes           | yes       | yes     | yes        | yes     | no     | yes
+| function    | no [1]        | yes       | yes     | yes        | yes     | no     | yes
 
 | value types | N/A           | N/A       | N/A     | N/A       | N/A     | N/A    | N/A
 
 |===
+
+[1] Calls to function `static_assert` are exceptionally allowed at the top level.
 
 There may not be any recursion in calls, neither by a thing calling
 itself directly, nor mutual recursion.

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -9569,7 +9569,7 @@ state declarations, or within a control declaration, but outside its
 
 | control     | no            |  no       | yes     | no        | no      | no     | no
 
-| extern      | yes           | yes       | yes     | yes       | yes     | no     | yes
+| extern      | no            | yes       | yes     | yes       | yes     | no     | yes
 
 | table       | no            |  no       | yes     | no        | no      | no     | no
 


### PR DESCRIPTION
Following the discussion in #1349, this proposes some relaxation to **Appendix F: Restrictions on compile time and run time calls**.

**First, for runtime calls**,

(Current)

![image](https://github.com/user-attachments/assets/fda9474d-e5ed-4d93-84f8-e775505cb1b1)

(Proposed) (EDITED)

![image](https://github.com/user-attachments/assets/da802bbe-3693-46ee-b0f0-b276d3ba25bd)

(1) It adds a new column *top level* and refines the column *parser or control top level* (it is written *parser or top level* in the image, but it is likely a typo introduced while migrating to asciidoc) to *top level within a parser or control*.

(2) The explainer for the table has been modified such that the row *extern* means: both an extern method and a function, while it previously meant only the former. Also, the row *function* means: functions but not extern functions. (EDITED) 

(3) It *allows* function calls at the *top level within a parser or control*, but *disallows* function calls at the *top level*. (EDITED)

Allowing function calls at the top level within a parser or control reflects the use case demonstrated in p4c tests: [issue1538.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue1538.p4), [issue2957.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue2957.p4), [issue2488-bmv2.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue2488-bmv2.p4), [issue2543-1.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue2543-1.p4). (EDITED)

For instance,

```p4
bit<16> incr(in bit<16> x) {
    return x + 1;
}
parser ParserImpl(packet_in packet,
                  out headers hdr,
                  inout metadata meta,
                  inout standard_metadata_t standard_metadata) {
    bit<16> tmp_port = incr((bit<16>) standard_metadata.ingress_port);
    ...
}
```

(4) It *allows* extern calls at a function. This reflects the use case in [issue3274.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue3274.p4), [issue3274-2.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue3274-2.p4), [issue3292.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue3292.p4), and [issue4500.p4](https://github.com/p4lang/p4c/blob/main/testdata/p4_16_samples/issue4500.p4).

```p4
extern bit<32> f(in bit<32> x, out bit<16> y);
bit<32> x() {
    return f(x = 1, y = _);
}
```

**Second, for compile-time constructor calls,**

(Current)

![image](https://github.com/user-attachments/assets/62ccd166-df1c-4be2-a112-ba414743da0a)

(Proposed)

![image](https://github.com/user-attachments/assets/9cbe01d4-1c5a-452d-a4b1-c443393b4f2e)

The column for *package* has been modified to allow instantiation of package, parser, control, and extern. Here, "*this type* can be instantiated in a package" means, that, *this type* can be instantiated as a constructor parameter for a package.

Note that a package instantiation can only happen at the top-level, while it involves nameless instantiations of package, parser, control, and extern objects as constructor arguments. With the current restriction, there is no clear way of classifying such nameless instantiation according to the table. But with the revised restriction, we may consider them as valid.