### PR TITLE
Update grammar to be closer to p4c implementation 2025 feb

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5484,6 +5484,8 @@ statement
     ;
 
 include::grammar.adoc[tag=assignmentOrMethodCallStatement]
+
+include::grammar.adoc[tag=assignmentOrMethodCallStatementWithoutSemicolon]
 ----
 
 In addition, parsers support a `transition` statement (<<sec-transition>>).
@@ -5730,18 +5732,28 @@ for possible techniques that one might
 use to implement generalized switch statements.footnote:GeneralizedSwitchStatements[<https://github.com/p4lang/p4-spec/blob/master/p4-16/spec/docs/implementing-generalized-switch-statements.md>]
 
 [#sec-loop-stmt]
-=== Loop statement
+=== For statement
 
-A `loop` statement executes a statement zero or more times, based on a
+A `for` statement executes a statement zero or more times, based on a
 condition or a range or collection.
 
 [source,bison]
 ----
-include::grammar.adoc[tag=loopStatement]
+include::grammar.adoc[tag=forStatement]
 
-include::grammar.adoc[tag=forInitStatement]
+include::grammar.adoc[tag=forInitStatements]
 
-include::grammar.adoc[tag=forUpdateStatement]
+include::grammar.adoc[tag=forInitStatementsNonEmpty]
+
+include::grammar.adoc[tag=declOrAssignmentOrMethodCallStatement]
+
+include::grammar.adoc[tag=forUpdateStatements]
+
+include::grammar.adoc[tag=forUpdateStatementsNonEmpty]
+
+include::grammar.adoc[tag=forCollectionExpr]
+
+include::grammar.adoc[tag=assignmentOrMethodCallStatementWithoutSemicolon]
 ----
 
 The basic 3-clause `for` statement is similar to a C `for` statement.  The init statements

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -9090,6 +9090,7 @@ The P4 compiler should provide:
 
 * Clarified that numeric priorities cannot be assigned to entries of a table that has `const entries` (<<sec-entries>>).
 * Clarified that `switch` statements are allowed in action and function bodies, and that `switch` statements with `action_run` expressions are only allowed in control `apply` blocks (<<sec-stmts>> and <<sec-switch-stmt>>).
+* Update the specification grammar for `for` loops to match the grammar used in the `p4c` implementation (<<sec-loop-stmt>>).
 
 === Summary of changes made in version 1.2.5, released October 11, 2024
 

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -734,11 +734,17 @@ typedefDeclaration
 
 // tag::assignmentOrMethodCallStatement[]
 assignmentOrMethodCallStatement
-    : lvalue "(" argumentList ")" ";"
-    | lvalue "<" typeArgumentList ">" "(" argumentList ")" ";"
-    | lvalue "="  expression ";"
+    : assignmentOrMethodCallStatementWithoutSemicolon ";"
     ;
 // end::assignmentOrMethodCallStatement[]
+
+// tag::assignmentOrMethodCallStatementWithoutSemicolon[]
+assignmentOrMethodCallStatementWithoutSemicolon
+    : lvalue "(" argumentList ")"
+    | lvalue "<" typeArgumentList ">" "(" argumentList ")"
+    | lvalue "="  expression
+    ;
+// end::assignmentOrMethodCallStatementWithoutSemicolon[]
 
 // tag::emptyStatement[]
 emptyStatement
@@ -797,7 +803,7 @@ statement
     | continueStatement
     | exitStatement
     | switchStatement
-    | loopStatement
+    | forStatement
     ;
 
 // tag::blockStatement[]
@@ -848,58 +854,49 @@ statementOrDeclaration
     ;
 // end::statementOrDeclaration[]
 
-// tag::loopStatement[]
-loopStatement
-    : optAnnotations FOR "(" optForInitStatements ";" expression ";"
-      optForUpdateStatements ")" statement
+// tag::forStatement[]
+forStatement
+    : optAnnotations FOR "(" forInitStatements ";" expression ";"
+      forUpdateStatements ")" statement
     | optAnnotations FOR "(" typeRef name IN forCollectionExpr ")" statement
+    | optAnnotations FOR "(" annotations typeRef name IN forCollectionExpr ")" statement
     ;
-// end::loopStatement[]
-
-// tag::optForInitStatements[]
-optForInitStatements
-    : /* empty */
-    | forInitStatements
-    ;
-// end::optForInitStatements[]
+// end::forStatement[]
 
 // tag::forInitStatements[]
 forInitStatements
-    : forInitStatement
-    | forInitStatements "," forInitStatement
+    : /* empty */
+    | forInitStatementsNonEmpty
     ;
 // end::forInitStatements[]
 
-// tag::forInitStatement[]
-forInitStatement
-    : optAnnotations typeRef name optInitializer
-    | lvalue "(" argumentList ")"
-    | lvalue "<" typeArgumentList ">" "(" argumentList ")"
-    | lvalue "=" expression
+// tag::forInitStatementsNonEmpty[]
+forInitStatementsNonEmpty
+    : declOrAssignmentOrMethodCallStatement
+    | forInitStatementsNonEmpty "," declOrAssignmentOrMethodCallStatement
     ;
-// end::forInitStatement[]
+// end::forInitStatementsNonEmpty[]
 
-// tag::optForUpdateStatements[]
-optForUpdateStatements
-    : /* empty */
-    | forUpdateStatements
+// tag::declOrAssignmentOrMethodCallStatement[]
+declOrAssignmentOrMethodCallStatement
+    : variableDeclarationWithoutSemicolon
+    | assignmentOrMethodCallStatementWithoutSemicolon
     ;
-// end::optForUpdateStatements[]
+// end::declOrAssignmentOrMethodCallStatement[]
 
 // tag::forUpdateStatements[]
 forUpdateStatements
-    : forUpdateStatement
-    | forUpdateStatements "," forUpdateStatement
+    : /* empty */
+    | forUpdateStatementsNonEmpty
     ;
 // end::forUpdateStatements[]
 
-// tag::forUpdateStatement[]
-forUpdateStatement
-    : lvalue "(" argumentList ")"
-    | lvalue "<" typeArgumentList ">" "(" argumentList ")"
-    | lvalue "=" expression
+// tag::forUpdateStatementsNonEmpty[]
+forUpdateStatementsNonEmpty
+    : assignmentOrMethodCallStatementWithoutSemicolon
+    | forUpdateStatementsNonEmpty "," assignmentOrMethodCallStatementWithoutSemicolon
     ;
-// end::forUpdateStatement[]
+// end::forUpdateStatementsNonEmpty[]
 
 // tag::forCollectionExpr[]
 forCollectionExpr
@@ -990,8 +987,12 @@ actionDeclaration
 
 // tag::variableDeclaration[]
 variableDeclaration
-    : annotations typeRef name optInitializer ";"
-    | typeRef name optInitializer ";"
+    : variableDeclarationWithoutSemicolon ";"
+    ;
+
+variableDeclarationWithoutSemicolon
+    : annotations typeRef name optInitializer
+    | typeRef name optInitializer
     ;
 // end::variableDeclaration[]
 

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -740,18 +740,6 @@ assignmentOrMethodCallStatement
     ;
 // end::assignmentOrMethodCallStatement[]
 
-// tag::breakStatement[]
-breakStatement
-    : BREAK ";"
-    ;
-// end::breakStatement[]
-
-// tag::continueStatement[]
-continueStatement
-    : CONTINUE ";"
-    ;
-// end::continueStatement[]
-
 // tag::emptyStatement[]
 emptyStatement
     : ";"
@@ -778,6 +766,18 @@ conditionalStatement
     ;
 // end::conditionalStatement[]
 
+// tag::breakStatement[]
+breakStatement
+    : BREAK ";"
+    ;
+// end::breakStatement[]
+
+// tag::continueStatement[]
+continueStatement
+    : CONTINUE ";"
+    ;
+// end::continueStatement[]
+
 // To support direct invocation of a control or parser without instantiation
 // tag::directApplication[]
 directApplication
@@ -793,9 +793,9 @@ statement
     | emptyStatement
     | blockStatement
     | returnStatement
-    | exitStatement
     | breakStatement
     | continueStatement
+    | exitStatement
     | switchStatement
     | loopStatement
     ;
@@ -839,6 +839,14 @@ switchLabel
     | nonBraceExpression
     ;
 // end::switchLabel[]
+
+// tag::statementOrDeclaration[]
+statementOrDeclaration
+    : variableDeclaration
+    | constantDeclaration
+    | statement
+    ;
+// end::statementOrDeclaration[]
 
 // tag::loopStatement[]
 loopStatement
@@ -896,17 +904,9 @@ forUpdateStatement
 // tag::forCollectionExpr[]
 forCollectionExpr
     : expression
-    | expression ".." erxpression
+    | expression ".." expression
     ;
 // end::forCollectionExpr[]
-
-// tag::statementOrDeclaration[]
-statementOrDeclaration
-    : variableDeclaration
-    | constantDeclaration
-    | statement
-    ;
-// end::statementOrDeclaration[]
 
 /************************* TABLE *********************************/
 

--- a/p4-16/spec/scripts/README.md
+++ b/p4-16/spec/scripts/README.md
@@ -6,5 +6,5 @@ directory to compare the spec's grammar.mdk file against that p4c
 repo's version of the grammar:
 
 ```bash
-./compare-grammar.sh ../grammar.mdk $HOME/p4c/frontends/parsers/p4/p4parser.ypp
+./compare-grammar.sh ../grammar.adoc $HOME/p4c/frontends/parsers/p4/p4parser.ypp
 ```


### PR DESCRIPTION
This PR intentionally has 2 commits, in hopes of making it slightly easier to review.

The first commit _only_ reorders some definitions of nonterminal symbols in the grammar, without changing their contents at all in any other way, to make the order the same as the p4c implementation grammar, for easier diff'ing.  OK, that plus fixing one typo in a nonterminal name, and updating an example command in scripts/README.md for running that can help with easier diff'ing of the spec grammar vs. the p4c implementation grammar.

The second commit _only_ updates the definitions of nonterminals related to the new `for` loops, to make them closer to the p4c implementation grammar.  Those are the ones that require closer scrutiny on review, I think.