### PR TITLE
Update grammar.adoc to include abstract method declarations

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -2747,11 +2747,7 @@ to a target.
 ----
 include::grammar.adoc[tag=methodPrototypes]
 
-methodPrototype
-    : optAnnotations functionPrototype ';'
-    | optAnnotations TYPE_IDENTIFIER '(' parameterList ')' ';' //constructor
-    | optAnnotations ABSTRACT functionPrototype ";"
-    ;
+include::grammar.adoc[tag=methodPrototype]
 
 include::grammar.adoc[tag=typeOrVoid]
 

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -82,6 +82,13 @@ annotation
     ;
 // end::annotation[]
 
+// tag::structuredAnnotationBody[]
+structuredAnnotationBody
+    : expressionList optTrailingComma
+    | kvList optTrailingComma
+    ;
+// end::structuredAnnotationBody[]
+
 // tag::annotationBody[]
 annotationBody
     : /* empty */
@@ -497,8 +504,8 @@ functionPrototype
 // tag::methodPrototype[]
 methodPrototype
     : optAnnotations functionPrototype ";"
-    | optAnnotations TYPE_IDENTIFIER "(" parameterList ")" ";"
     | optAnnotations ABSTRACT functionPrototype ";"
+    | optAnnotations TYPE_IDENTIFIER "(" parameterList ")" ";"
     ;
 // end::methodPrototype[]
 
@@ -1069,13 +1076,6 @@ expressionList
     | expressionList "," expression
     ;
 // end::expressionList[]
-
-// tag::structuredAnnotationBody[]
-structuredAnnotationBody
-    : expressionList optTrailingComma
-    | kvList optTrailingComma
-    ;
-// end::structuredAnnotationBody[]
 
 // tag::member[]
 member

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -494,10 +494,13 @@ functionPrototype
     ;
 // end::functionPrototype[]
 
+// tag::methodPrototype[]
 methodPrototype
     : optAnnotations functionPrototype ";"
     | optAnnotations TYPE_IDENTIFIER "(" parameterList ")" ";"
+    | optAnnotations ABSTRACT functionPrototype ";"
     ;
+// end::methodPrototype[]
 
 /************************** TYPES ****************************/
 


### PR DESCRIPTION
The language specification added this rule in July 2019, but it was never added to the file grammar.adoc (formerly grammar.mdk), which appears to simply have been an oversight.