### PR TITLE
enable CI build workflow on PRs

### DIFF
--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -1,9 +1,7 @@
 name: Build and push specification files
 
-on:
-  push:
-    branches:
-      - '**'
+on: [push, pull_request]
+
 jobs:
   build:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Make it so that CI is run for pull requests. This is helpful when reviewing request and for PR submitters to see the CI rendering of spec changes.