### PR TITLE
Allow default initializer when all fields are initialized

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5173,9 +5173,11 @@ suitable type using the syntax `+...+` (see <<sec-default-values>>).  A value
 of type `struct`, `header`, or `tuple` can also be initialized using a mix of
 explicit values and default values by using the notation `+...+` in a tuple
 expression initializer; in this case all fields not explicitly
-initialized are initialized with default values.  When initializing a `struct`,
-`header`, and `tuple` with a value containing partially default values
-using the `+...+` notation the three dots must appear last in the initializer.
+initialized are initialized with default values. It is permissible to use
+`+...+` when all fields have been explicitly initialized, in which case it
+has no effect. When initializing a `struct`, `header`, and `tuple` with a
+value containing partially default values using the `+...+` notation the
+three dots must appear last in the initializer.
 
 [source,p4]
 ----


### PR DESCRIPTION
As discussed in the last LDWG meeting regarding [p4c#5265](https://github.com/p4lang/p4c/issues/5265#issuecomment-3267278335), we would like to mention that it is allowed to use `...` when all fields have been initialized. This PR adds the bolded line to **8.27 Initializing with default values** of the spec:

> A left-value can be initialized automatically with a default value of the suitable type using the syntax `...` (see *sec-default-values*).  A value of type `struct`, `header`, or `tuple` can also be initialized using a mix of explicit values and default values by using the notation `...` in a tuple expression initializer; in this case all fields not explicitly initialized are initialized with default values. **It is permissible to use `...` when all fields have been explicitly initialized, in which case it has no effect.** When initializing a `struct`, `header`, and `tuple` with a value containing partially default values using the `...` notation the three dots must appear last in the initializer.
