### PR TITLE
Disallow duplicate declarations within the same scope

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -1361,6 +1361,9 @@ declaration. (This is a departure from P4~14~, which
 allows declarations in any order. This requirement significantly simplifies the implementation of
 compilers for P4, allowing compilers to use additional information
 about declared identifiers to resolve ambiguities.)
+Except for functions and methods, which may be overloaded, duplicate
+declarations of the same name within the same scope are not allowed.
+<<sec-name-resolution>> describes how names are resolved in P4.
 
 [#sec-stateful-elems]
 ==== Stateful elements
@@ -1767,6 +1770,52 @@ control p() {
     const bit<8> z = x;    // reference to p's local x
     apply {}
 }
+----
+
+Declaring a duplicate identifier in the same scope is disallowed. This is
+different from shadowing. Shadowing occurs when an identifier declared in an
+_inner_ scope has the same name as an identifier declared in an _outer_ scope.
+Duplicate declarations occur when two identifiers with the same name are
+declared in the _same_ scope.
+
+[source,p4]
+----
+const bit<4> x = 1;
+control p() {
+    const bit<8> x = 8;   // x declaration shadows global x
+    const bit<4> x = 4;   // Error: duplicate declaration of x
+    apply {}
+}
+----
+
+Functions and methods are the only P4 constructs that support overloading:
+there _can_ exist multiple methods with the same name in the same scope. When
+overloading is used, the compiler must be able to disambiguate at compile-time
+which method or function is being called, either by the number of arguments or
+by the names of the arguments, when calls are specifying argument names.
+Argument type information is _not_ used in disambiguating calls.
+
+[source,p4]
+----
+extern void f(in bit<8> x);
+extern void f(in bit<8> y); // allowed: different parameter names
+extern void f(in bit<16> x, in bit<8> y); // allowed: different number of parameters
+extern void f(in bit<16> x, in bit<8> x); // Error: duplicate declaration of previous function
+----
+
+Notice that overloading of abstract methods, parsers, controls, or packages is
+not allowed:
+
+[source,p4]
+----
+parser p(packet_in p, out bit<32> value) {
+  ...
+}
+
+// The following will cause an error about a duplicate declaration
+//parser p(packet_in p, out Headers headers) {
+//   ...
+//}
 ----
 
 [#sec-name-visibility]
@@ -2818,28 +2867,6 @@ control d(packet_out b, in Hdr h) {
         b.emit(h.ipv4);       // write ipv4 header into output packet
     }                         // by calling emit method
 }
-----
-
-Functions and methods are the only P4 constructs that support
-overloading: there can exist multiple methods with the same name in
-the same scope.  When overloading is used, the compiler must be able to
-disambiguate at compile-time which method or function is being called,
-either by the number of arguments or by the names of the arguments,
-when calls are specifying argument names.  Argument type information
-is not used in disambiguating calls.
-
-Notice that overloading of abstract methods, parsers, controls, or packages is not allowed:
-
-[source,p4]
-----
-parser p(packet_in p, out bit<32> value) {
-  ...
-}
-
-// The following will cause an error about a duplicate declaration
-//parser p(packet_in p, out Headers headers) {
-//   ...
-//}
 ----
 
 [#sec-abstract-methods]

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -1800,7 +1800,7 @@ Argument type information is _not_ used in disambiguating calls.
 extern void f(in bit<8> x);
 extern void f(in bit<8> y); // allowed: different parameter names
 extern void f(in bit<16> x, in bit<8> y); // allowed: different number of parameters
-extern void f(in bit<16> x, in bit<8> x); // Error: duplicate declaration of previous function
+extern void f(in bit<16> x, in bit<8> y); // Error: duplicate declaration of previous function
 ----
 
 Notice that overloading of abstract methods, parsers, controls, or packages is


### PR DESCRIPTION
This PR revises the specification to disallow duplicate declarations within the *same* scope. This has been discussed in P4 LDWG.

* It disallows duplicate declarations, e.g.,

```p4
control p() {
    const bit<8> x = 8;
    const bit<4> x = 4;   // Error: duplicate declaration of x
    apply {}
}
```

* But it still allows declaration shadowing (same identifier in an *inner* scope), e.g.,

```p4
const bit<4> x = 1;
control p() {
    const bit<8> x = 8;   // x declaration shadows global x
    apply {}
}
```

* And it still allows functions and methods with the same names (up to overload resolution). Recall that P4 allows overloading of functions and methods, when they can be differentiated by either the number of parameters or the names of parameters:

```p4
extern void f(in bit<8> x);
extern void f(in bit<8> y); // allowed: different parameter names
extern void f(in bit<16> x, in bit<8> y); // allowed: different number of parameters
extern void f(in bit<16> x, in bit<8> x); // Error: duplicate declaration of previous function
```
Some related past issues in p4-spec and p4c are:

* p4lang/p4-spec#974
  * This is perhaps the first issue asking for clarification regarding name duplication. Was closed after it got stale.
* p4lang/p4c#5096
  * The recent p4c issue, which led to a discussion in 2025-November P4 LDWG meeting. The consensus was to disallow duplicate declarations within the same scope.

In particular, this PR modifies sections **6.6.1. Scopes**, **6.9. Name Resolution**, and **7.2.11.2. Extern Objects**.

* **6.6.1** add that duplicate declarations are disallowed.
* **6.9** adds a detailed explanation of duplicate declaration, and also explains that name shadowing (up to compiler warning) and function/method overloading are still allowed.
* The part explaining function/method overloading in **7.2.11.2** was moved to **6.9**. 