### PR TITLE
Add bounded for statements

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5883,13 +5883,17 @@ The scope of any declaration in a `for` statement is limited to the `for` statem
 
 ==== Bounded for statement
 
-A bounded `for` statement is a `for` statement with stronger syntactic constraints to ensure its boundedness statically.
+A P4 implementation may support a bounded version of `for` statements with stronger syntactic constraints instead of general `for` statements to ensure its boundedness statically.
 
 [source,bison]
 ----
 include::grammar.adoc[tag=boundedForStatement]
 
-include::grammar.adoc[tag=assignmentStatementWithoutSemicolon]
+include::grammar.adoc[tag=boundedForInitStatement]
+
+include::grammar.adoc[tag=boundedForCondExpr]
+
+include::grammar.adoc[tag=boundedForUpdateStatement]
 ----
 
 `for`-`in` statements remain the same as general `for`-`in` statements as a `forCollectionExpr` always contains finitely many values. However, 3-clause `for` statements are not guaranteed to be bounded in general. The following constraints are added to bounded 3-clause `for` statements:
@@ -5897,7 +5901,7 @@ include::grammar.adoc[tag=assignmentStatementWithoutSemicolon]
 - Only one variable is mentioned in the initialization statement, condition expression, and the update statement. We call this variable the "loop variable".
 - There is only one init statement, which declares and initializes the loop variable.
 - The condition expression must be a binary expression `i < n` where `i` is the loop variable.
-- There is only one update statement, which must be an assignment statement `i = i + c`. `i` is the loop variable and `c` must be a positive local compile-time known value.
+- There is only one update statement, which must be an assignment statement `i += 1` where `i` is the loop variable.
 - The loop variable is a read-only variable within the loop body and the condition expression. It can only be overwritten by the update statement.
 
 The above constraints guarantee boundedness since the loop variable monotonically increases and has an upper bound.

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5881,6 +5881,29 @@ either execute the loop body again, or terminate the loop.
 
 The scope of any declaration in a `for` statement is limited to the `for` statement and its body.
 
+==== Bounded for statement
+
+A bounded `for` statement is a `for` statement with stronger syntactic constraints to ensure its boundedness statically.
+
+[source,bison]
+----
+include::grammar.adoc[tag=boundedForStatement]
+
+include::grammar.adoc[tag=assignmentStatementWithoutSemicolon]
+----
+
+`for`-`in` statements remain the same as general `for`-`in` statements as a `forCollectionExpr` always contains finitely many values. However, 3-clause `for` statements are not guaranteed to be bounded in general. The following constraints are added to bounded 3-clause `for` statements:
+
+- Only one variable is mentioned in the initialization statement, condition expression, and the update statement. We call this variable the "loop variable".
+- There is only one init statement, which declares and initializes the loop variable.
+- The condition expression must be a binary expression `i < n` where `i` is the loop variable.
+- There is only one update statement, which must be an assignment statement `i = i + c`. `i` is the loop variable and `c` must be a positive local compile-time known value.
+- The loop variable is a read-only variable within the loop body and the condition expression. It can only be overwritten by the update statement.
+
+The above constraints guarantee boundedness since the loop variable monotonically increases and has an upper bound.
+
+The semantics of bounded `for` statements are the same as general `for` statements.
+
 [#sec-packet-parsing]
 == Packet parsing
 

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5887,6 +5887,8 @@ The scope of any declaration in a `for` statement is limited to the `for` statem
 
 A P4 implementation may support a bounded version of `for` statements with stronger syntactic constraints instead of general `for` statements to ensure its boundedness statically.
 
+This is intended to be a _minimal_ subset of bounded `for` statements. A P4 implementation that supports bounded `for` statements may choose to implement a larger subset; furthermore, it may reject a `for` statement if its bound is too large, even if it is statically bounded.
+
 [source,bison]
 ----
 include::grammar.adoc[tag=boundedForStatement]
@@ -5900,15 +5902,15 @@ include::grammar.adoc[tag=boundedForUpdateStatement]
 
 `for`-`in` statements remain the same as general `for`-`in` statements as a `forCollectionExpr` always contains finitely many values. However, 3-clause `for` statements are not guaranteed to be bounded in general. The following constraints are added to bounded 3-clause `for` statements:
 
-- Only one variable is mentioned in the initialization statement, condition expression, and the update statement. We call this variable the "loop variable".
-- There is only one init statement, which declares and initializes the loop variable.
-- The condition expression must be a binary expression `i < n` where `i` is the loop variable and `n` is a local compile time known value.
-- There is only one update statement, which must be an assignment statement `i += 1` where `i` is the loop variable.
+- Only one variable is mentioned in the initialization statement, condition expression, and the update statement. We call this variable the "loop variable". The type of the loop variable must be `bit<W>` or `int<W>`.
+- The condition expression must be a binary expression `i < n` where `i` is the loop variable and `n` is a local compile-time known value.
+- There is only one update statement, which must be an assignment statement `i += c` where `i` is the loop variable and `c` is a positive local compile-time known value.
+- Referring to `n` and `c` above, the sum `n + c` should not overflow with respect to the type of the loop variable.
 - The loop variable is a read-only variable within the loop body and the condition expression. It can only be overwritten by the update statement.
 
 The above constraints guarantee boundedness since the loop variable monotonically increases and has an upper bound.
 
-The semantics of bounded `for` statements are the same as general `for` statements.
+The runtime semantics of bounded `for` statements are the same as general `for` statements.
 
 [#sec-packet-parsing]
 == Packet parsing

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5872,6 +5872,8 @@ element in a list expression, array or header stack.  The list or range expressi
 will only be evaluated once, before the first iteration of the loop.  All side effects
 in the list or range expression will occur before the first iteration of the loop body.
 
+Instantiations are not allowed within `for` statements.
+
 A `break;` statement may be executed in a loop body to immediately exit the loop,
 without executing the rest of the body or the update statements.
 

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -5902,7 +5902,7 @@ include::grammar.adoc[tag=boundedForUpdateStatement]
 
 - Only one variable is mentioned in the initialization statement, condition expression, and the update statement. We call this variable the "loop variable".
 - There is only one init statement, which declares and initializes the loop variable.
-- The condition expression must be a binary expression `i < n` where `i` is the loop variable.
+- The condition expression must be a binary expression `i < n` where `i` is the loop variable and `n` is a local compile time known value.
 - There is only one update statement, which must be an assignment statement `i += 1` where `i` is the loop variable.
 - The loop variable is a read-only variable within the loop body and the condition expression. It can only be overwritten by the update statement.
 

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -926,6 +926,20 @@ forCollectionExpr
     ;
 // end::forCollectionExpr[]
 
+// tag::boundedForStatement[]
+boundedForStatement
+    : optAnnotations FOR "(" variableDeclarationWithoutSemicolon ";"
+      expression ";" assignmentStatementWithoutSemicolon ")" statement
+    | optAnnotations FOR "(" typeRef name IN forCollectionExpr ")" statement
+    | optAnnotations FOR "(" annotations typeRef name IN forCollectionExpr ")" statement
+    ;
+// end::boundedForStatement[]
+
+// tag::assignmentStatementWithoutSemicolon[]
+assignmentStatementWithoutSemicolon 
+    : lvalue "=" expression
+// end::assignmentStatementWithoutSemicolon[]
+
 /************************* TABLE *********************************/
 
 // tag::tableDeclaration[]

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -953,11 +953,6 @@ boundedForUpdateStatement
     ;
 // end::boundedForUpdateStatement[]
 
-// tag::assignmentStatementWithoutSemicolon[]
-assignmentStatementWithoutSemicolon 
-    : lvalue "=" expression
-// end::assignmentStatementWithoutSemicolon[]
-
 /************************* TABLE *********************************/
 
 // tag::tableDeclaration[]

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -927,13 +927,31 @@ forCollectionExpr
 // end::forCollectionExpr[]
 
 // tag::boundedForStatement[]
-boundedForStatement
-    : optAnnotations FOR "(" variableDeclarationWithoutSemicolon ";"
-      expression ";" assignmentStatementWithoutSemicolon ")" statement
+forStatement
+    : optAnnotations FOR "(" boundedForInitStatement ";" boundedForCondExpr ";"
+      boundedForUpdateStatement ")" statement
     | optAnnotations FOR "(" typeRef name IN forCollectionExpr ")" statement
     | optAnnotations FOR "(" annotations typeRef name IN forCollectionExpr ")" statement
     ;
 // end::boundedForStatement[]
+
+// tag::boundedForInitStatement[]
+boundedForInitStatement
+    : typeRef name "=" initializer
+    ;
+// end::boundedForInitStatement[]
+
+// tag::boundedForCondExpr[]
+boundedForCondExpr
+    : name '<' expression
+    ;
+// end::boundedForCondExpr[]
+
+// tag::boundedForUpdateStatement[]
+boundedForUpdateStatement
+    : name "+=" INTEGER
+    ;
+// end::boundedForUpdateStatement[]
 
 // tag::assignmentStatementWithoutSemicolon[]
 assignmentStatementWithoutSemicolon 


### PR DESCRIPTION
This PR adds a new subsection **12.8.1. Bounded for statement** under **12.8. For statement**.

Bounded `for` statements form a subset of general `for` statements, and are ensured to be bounded statically by adding the following syntactic constraints:

- Only one variable is mentioned in the initialization statement, condition expression, and the update statement. We call this variable the "loop variable".
- There is only one init statement, which declares and initializes the loop variable.
- The condition expression must be a binary expression `i < n` where `i` is the loop variable and `n` is a local compile time known value.
- There is only one update statement, which must be an assignment statement `i += 1` where `i` is the loop variable.
- The loop variable is a read-only variable within the loop body and the condition expression. It can only be overwritten by the update statement.

For example, this is a bounded for statement, which is a common use of `for` statements:
```p4
bit<8> result = 0;
for (bit<8> i = 0; i < 8; i += 1) {
    result = result + i;
}
```

On the other hand, these `for` statements are not considered as bounded `for` statements, though they may be actually bounded:
```p4
bit<8> result = 0;
bit<8> j;
// The init statement must declare and initialize the loop variable
for (j = 0; j < 8; j += 1) {
    result = result + j;
}
// The condition expression must be in the form i < c
for (bit<8> i = 0; i != 8; i += 1) {
    result = result + i;
}
// The update statement must increment i by 1
for (bit<8> i = 0; i < 8; i = i << 1) {
    result = result + i;
}
// i is not modifiable within the loop
for (bit<8> i = 0; i < 8; i += 1) {
    result = result + i;
    i = i + 1;
}
```

For now, this version states a very simple subset of bounded `for` statements. This PR is meant to be a starting point of the discussion on adding bounded `for` statements to the specification.

Additionally, one restriction is added, which also corresponds to general `for` statements:
* Instantiations are not allowed within `for` statements.