### PR TITLE
Fix Asciidoctor error in P4-16 spec

### DIFF
--- a/p4-16/psa/Makefile
+++ b/p4-16/psa/Makefile
@@ -8,17 +8,22 @@ all: ${SPEC}.pdf ${SPEC}.html charter
 
 ${SPEC}.pdf: ${SPEC}.adoc
 	asciidoctor-pdf -v \
+		--failure-level ERROR \
 		-a pdf-fontsdir=resources/fonts \
 		-a rouge-style=$(ROUGE_STYLE) $<
 
 ${SPEC}.html: ${SPEC}.adoc
-	asciidoctor -v -a rouge-css=$(ROUGE_CSS) $<
+	asciidoctor -v \
+		--failure-level ERROR \
+		-a rouge-css=$(ROUGE_CSS) $<
 
 charter:
 	$(MAKE) -C charter
 
 clean:
-	${RM} -rf build
+	/bin/rm -f ${SPEC}.pdf ${SPEC}.html
+
+#	/bin/rm -f ${SPEC}.pdf ${SPEC}.html grammar.trimmed.adoc resources/figs/stem-*.png
 
 # Disabling warnings about uninitialized_out_param, because those
 # regularly occur with these example programs for the 'out

--- a/p4-16/spec/Makefile
+++ b/p4-16/spec/Makefile
@@ -9,12 +9,14 @@ grammar.trimmed.adoc: grammar.adoc trim-asciidoc-tag-comments.py
 
 ${SPEC}.pdf: ${SPEC}.adoc grammar.adoc grammar.trimmed.adoc
 	time asciidoctor-pdf -v \
+		--failure-level ERROR \
 		-r asciidoctor-mathematical \
 		-a pdf-fontsdir=resources/fonts \
 		-a rouge-style=$(ROUGE_STYLE) $<
 
 ${SPEC}.html: ${SPEC}.adoc grammar.adoc grammar.trimmed.adoc
 	time asciidoctor -v \
+		--failure-level ERROR \
 		-r asciidoctor-mathematical \
 		-a rouge-css=$(ROUGE_CSS) $<
 

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -2551,13 +2551,13 @@ Operations that manipulate list types are described in
 ==== Type nesting rules
 
 The table below lists all types that may appear as members of headers,
-header unions, structs, tuples, and lists.  Note that `int` by itself
+header unions, structs, tuples, lists, arrays, and header stacks.  Note that `int` by itself
 (i.e. not as part of an `int<N>` type expression) means an
 arbitrary-precision integer, without a width specified.
 
 [.center,%autowidth]
 |===
-| Element type 5+^| Container kind  
+| Element type 6+^| Container kind
 
 |                | header    | header_union | struct or tuple | list | array [4] | header stack
 
@@ -2595,15 +2595,15 @@ arbitrary-precision integer, without a width specified.
 
 | `list types`         | error     | error   |  error   | allowed | error [7] | error
 
-| `extern instances`   | error     | error   |  error   | erroe  | allowed [6] | error
+| `extern instances`   | error     | error   |  error   | error  | allowed [6] | error
 
-| `extern types`       | error     | error   |  error   | error   | error
+| `extern types`       | error     | error   |  error   | error   | error   | error
 
-| `parser types`       | error     | error   |  error   | error   | error
+| `parser types`       | error     | error   |  error   | error   | error   | error
 
-| `control types`      | error     | error   |  error   | error   | error
+| `control types`      | error     | error   |  error   | error   | error   | error
 
-| `package types`      | error     | error   |  error   | error   | error
+| `package types`      | error     | error   |  error   | error   | error   | error
 |===
 
 [1] An `enum` type used as a field in a `header` must specify a


### PR DESCRIPTION
Also modify Makefile so that if an Asciidoctor error occurs, the Github CI build will fail.