### PR TITLE
Specify behavior of +: slice used as l-value

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -3674,6 +3674,12 @@ Bit-strings also support the following operations:
   in which case an out of range value will be equivalent to a shift of that amount.
   An index that is not compile-time known must be a `bit<W>` type in order to ensure that
   it is non-negative.
+  Slices specified with `[L+:W]` are also l-values, which means that P4 supports
+  assigning to such a slice: `e[L+:W] = x`.
+  The effect of this statement is to set `W` bits starting from bit `L` of `e`
+  to the bit-pattern represented by `x`, and leaves all other bits of `e` unchanged.
+  If `L+W` exceeds the width of `e`, then only the bits that fall within the valid
+  range of `e` are modified.
 * Concatenation of bit-strings and/or fixed-width signed integers, denoted by `++`.
   The two operands must be either `bit<W>` or `int<W>`, and they can be of
   different signedness and width.  The result has the same signedness as the


### PR DESCRIPTION
This PR adds a description of the behavior of `+:` slices when they are used as l-values.

Unlike `:` style slices that check the bounds of both `H` and `L` at compile time, `+:` slices can potentially reference an out of bounds range. While the behavior of `+:` slices with an *in bounds* range is straightforward, the behavior of the *out of bounds* range case deserves explicit clarification. However, neither of them are currently described by the specification.

There has been prior discussion on how such cases should be handled.

> We should define semantics of out-of-bounds slices. Similar to how we have it defined for header stack indexing, we should not leave it to the compiler.
> * we might consider the "out-of-range" bits to be undefined
> * or we might want then to be 0s
> * we probably want write to out-of-bounds bits to have no effect.

https://github.com/p4lang/p4-spec/pull/1316#discussion_r1939466081

This PR adopts the interpretation that out-of-bounds bits have no effect, or are discarded, when `+:` out-of-bounds slices are used as l-values.

Related Issue: https://github.com/p4lang/p4-spec/issues/1390