### PR TITLE
Disallow optional parameters in parsers and controls, deprecate in abstract methods

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -1680,12 +1680,14 @@ void g()
 A parameter that is annotated with the `@optional` annotation is
 optional: the user may omit the value for that parameter in an
 invocation.  Optional parameters can only appear for arguments of:
-packages, parser types, control types, extern functions, extern methods, and extern object
-constructors.  Optional parameters cannot have default values.  If a
-procedure-like construct has both optional parameters and default values then it
-can only be called using named arguments.  It is recommended, but not
-mandatory, for all optional parameters to be at the end of a parameter
-list.
+packages, parser types, control types, extern functions, extern methods, and
+extern object constructors. Note that optional parameters are not allowed in
+parser declarations and control declarations. Allowing optional parameters in
+abstract methods is deprecated, and is planned to be disallowed in the future.
+Optional parameters cannot have default values.  If a procedure-like construct
+has both optional parameters and default values then it can only be called
+using named arguments.  It is recommended, but not mandatory, for all optional
+parameters to be at the end of a parameter list.
 
 The implementation of such objects is not expressed in P4, so the
 meaning and implementation of optional parameters should be specified


### PR DESCRIPTION
Closes #1383 
This PR is made from the April 2026 P4 LDWG meeting.

The PR explicitly disallows optional parameters in parser/control declarations and deprecates the use of optional parameters in abstract methods.

> Allowing optional parameters in abstract methods is deprecated, and is planned to be disallowed in the future.

@jonathan-dilorenzo @rcgoodfellow @jafingerhut I added this sentence under **Section 6.8.2. Optional parameters** for now, but would there be a better place to mention deprecated features in the specification, e.g. a new section in the Appendix?