### PR TITLE
Update asciidoctor install script for 2026

### DIFF
--- a/p4-16/spec/install-asciidoctor-linux.sh
+++ b/p4-16/spec/install-asciidoctor-linux.sh
@@ -17,8 +17,7 @@
 linux_version_warning() {
     1>&2 echo "Found ID ${ID} and VERSION_ID ${VERSION_ID} in /etc/os-release"
     1>&2 echo "This script only supports these:"
-    1>&2 echo "    ID ubuntu, VERSION_ID in 20.04 22.04 24.04"
-    #1>&2 echo "    ID fedora, VERSION_ID in 36 37 38"
+    1>&2 echo "    ID ubuntu, VERSION_ID in 22.04 24.04 26.04"
     1>&2 echo ""
     1>&2 echo "Proceed installing manually at your own risk of"
     1>&2 echo "significant time spent figuring out how to make it all"
@@ -46,10 +45,6 @@ tried_but_got_build_errors=0
 if [ "${ID}" = "ubuntu" ]
 then
     case "${VERSION_ID}" in
-	20.04)
-	    supported_distribution=1
-	    OS_SPECIFIC_PACKAGES="libgdk-pixbuf2.0-dev"
-	    ;;
 	22.04)
 	    supported_distribution=1
 	    OS_SPECIFIC_PACKAGES="libgdk-pixbuf-2.0-dev"
@@ -61,19 +56,6 @@ then
 	26.04)
 	    supported_distribution=1
 	    OS_SPECIFIC_PACKAGES="libgdk-pixbuf-2.0-dev"
-	    ;;
-    esac
-elif [ "${ID}" = "fedora" ]
-then
-    case "${VERSION_ID}" in
-	38)
-	    supported_distribution=0
-	    ;;
-	39)
-	    supported_distribution=0
-	    ;;
-	40)
-	    supported_distribution=0
 	    ;;
     esac
 fi

--- a/p4-16/spec/install-asciidoctor-linux.sh
+++ b/p4-16/spec/install-asciidoctor-linux.sh
@@ -170,7 +170,7 @@ SAVEDIR="${PWD}"
 mkdir -p "${HOME}"/install
 cd "${HOME}"/install
 CMAKE="cmake-3.31.9-linux-$(uname --machine)"
-curl -O "https://cmake.org/files/v3.31/${CMAKE_TGZ}.tar.gz"
+curl -O "https://cmake.org/files/v3.31/${CMAKE}.tar.gz"
 tar xkzf "${CMAKE}.tar.gz"
 export PATH="${PWD}/${CMAKE}/bin:${PATH}"
 cd "${SAVEDIR}"

--- a/p4-16/spec/install-asciidoctor-linux.sh
+++ b/p4-16/spec/install-asciidoctor-linux.sh
@@ -169,9 +169,7 @@ sudo apt-get --yes install cmake flex libglib2.0-dev libcairo2-dev libpango1.0-d
 SAVEDIR="${PWD}"
 mkdir -p "${HOME}"/install
 cd "${HOME}"/install
-ARCH=$(uname --machine)
-CMAKE="cmake-3.31.9-linux-${ARCH}"
-cmake-3.31.9-linux-aarch64
+CMAKE="cmake-3.31.9-linux-$(uname --machine)"
 curl -O "https://cmake.org/files/v3.31/${CMAKE_TGZ}.tar.gz"
 tar xkzf "${CMAKE}.tar.gz"
 export PATH="${PWD}/${CMAKE}/bin:${PATH}"
@@ -181,9 +179,7 @@ cd "${SAVEDIR}"
 gem install asciidoctor-mathematical
 gem install prawn-gmagick
 gem install rouge
-gem install asciidoctor-bibtex
 gem install asciidoctor-lists
-gem install prawn-gmagick
 
 which ruby
 ruby --version

--- a/p4-16/spec/install-asciidoctor-linux.sh
+++ b/p4-16/spec/install-asciidoctor-linux.sh
@@ -58,6 +58,10 @@ then
 	    supported_distribution=1
 	    OS_SPECIFIC_PACKAGES="libgdk-pixbuf-2.0-dev"
 	    ;;
+	26.04)
+	    supported_distribution=1
+	    OS_SPECIFIC_PACKAGES="libgdk-pixbuf-2.0-dev"
+	    ;;
     esac
 elif [ "${ID}" = "fedora" ]
 then
@@ -147,14 +151,33 @@ if [[ $UID == 0 ]]; then
 else
     source $HOME/.rvm/scripts/rvm
 fi
-rvm install ruby-3.3.1
-rvm use 3.3.1
+rvm install ruby-4.0.3
+rvm use 4.0.3
 gem install asciidoctor
 gem install asciidoctor-pdf
 gem install asciidoctor-bibtex
 # Additional installations to enable installing
 # asciidoctor-mathematical and prawn-gmagick
 sudo apt-get --yes install cmake flex libglib2.0-dev libcairo2-dev libpango1.0-dev libxml2-dev libwebp-dev libzstd-dev libgraphicsmagick1-dev libmagickwand-dev ${OS_SPECIFIC_PACKAGES}
+
+######################################################################
+# As of 2026-May-05, installing the ruby gem asciidoctor-mathematical
+# fails during building of native extensions on a system with a
+# too-recent version of cmake.  The most recent version of cmake that
+# I have tested successfully with is thus installed below and put
+# early in the command PATH.
+SAVEDIR="${PWD}"
+mkdir -p "${HOME}"/install
+cd "${HOME}"/install
+ARCH=$(uname --machine)
+CMAKE="cmake-3.31.9-linux-${ARCH}"
+cmake-3.31.9-linux-aarch64
+curl -O "https://cmake.org/files/v3.31/${CMAKE_TGZ}.tar.gz"
+tar xkzf "${CMAKE}.tar.gz"
+export PATH="${PWD}/${CMAKE}/bin:${PATH}"
+cd "${SAVEDIR}"
+######################################################################
+
 gem install asciidoctor-mathematical
 gem install prawn-gmagick
 gem install rouge


### PR DESCRIPTION
With these changes, I have tested that on freshly installed systems with all of the processor/Ubuntu-version combinations below, that after running the script you can build the PDF and HTML versions of the spec using the existing Makefile.

+ Ubuntu 22.04 - x86_64
+ Ubuntu 24.04 - x86_64 and aarch64
+ Ubuntu 26.04 - x86_64 and aarch64