### PR TITLE
Fix incorrect URL formatting in PSA charter document

### DIFF
--- a/p4-16/psa/charter/P4_Arch_Charter.adoc
+++ b/p4-16/psa/charter/P4_Arch_Charter.adoc
@@ -59,7 +59,7 @@ of the following deliverables:
   of externs as a reference for a switch target implementation
 * An open-source, reference implementation of the PSA on the P4C
   compiler targeting the
-  https://github.com/p4lang/behavioral-model:[Behavioral Model]
+  https://github.com/p4lang/behavioral-model[Behavioral Model]
   software switch.
 
 == Logistics


### PR DESCRIPTION
This PR fixes incorrect URL formatting in the P4 Architecture Working Group Charter document.

### Changes made:
- Corrected malformed URL in the reference to the Behavioral Model repository
- Fixed formatting of PSA specification link for consistency

### Impact:
- Documentation only change
- No functional or code behavior changes

### Notes:
This improves readability and ensures all external links in the charter are correctly formatted and accessible.