### PR TITLE
fix: add missing vars step and remove redundant -a flag in deploy job

### DIFF
--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -96,6 +96,9 @@ jobs:
         name: api-charter
         path: api-charter
 
+    - name: Set short SHA
+      id: vars
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Copy files
       run: |
@@ -111,7 +114,7 @@ jobs:
     - name: Commit changes
       run: |
         git add docs/P4-16-working-spec.{html,pdf} docs/PSA.{html,pdf} docs/P4_API_WG_charter.pdf docs/P4_Arch_Charter.html
-        git commit -am "docs for ${{ steps.vars.outputs.sha_short }}"
+        git commit -m "docs for ${{ steps.vars.outputs.sha_short }}"
 
     - name: Push commit to gh-pages branch
       run: git push -f origin gh-pages


### PR DESCRIPTION
The deploy job referenced `steps.vars.outputs.sha_short` but had no step with `id: vars` defined, causing every deploy commit message to read "docs for " with an empty SHA 

Also removed the `-a` flag from `git commit` since all files are
already explicitly staged by the preceding `git add`.