### PR TITLE
Add SDPX copyright and license annotation for all remaining files

### DIFF
--- a/.github/workflows/any-branch-uploads.yml
+++ b/.github/workflows/any-branch-uploads.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Any branch uploads
 
 on: workflow_dispatch

--- a/.github/workflows/asciidoc-build.yml
+++ b/.github/workflows/asciidoc-build.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Build and push specification files
 
 on: [push, pull_request]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 *.sw*
 !.github
 rouge

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2019 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 We expect all ONF employees, member companies, and participants to abide by our [Code of Conduct](https://www.opennetworking.org/wp-content/themes/onf/img/onf-code-of-conduct.pdf).
 
 If you are being harassed, notice that someone else is being harassed, or have any other concerns involving someone’s welfare, please notify a member of the ONF team or email [conduct@opennetworking.org](conduct@opennetworking.org). 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,1 @@
+LICENSES/Apache-2.0.txt

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # P4 programming language specifications
 
 - api: This folder keeps documents related to P4 run-time API discussions.

--- a/api/P4_API_WG_announcement_05_17_2017.pdf.license
+++ b/api/P4_API_WG_announcement_05_17_2017.pdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/api/PI_presentation_06_06_2016.pdf.license
+++ b/api/PI_presentation_06_06_2016.pdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/api/charter/.gitignore
+++ b/api/charter/.gitignore
@@ -1,2 +1,6 @@
+# SPDX-FileCopyrightText: 2017 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 build/
 *.pdf

--- a/api/charter/Makefile
+++ b/api/charter/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2017 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 SPEC=P4_API_WG_charter
 ROUGE_STYLE=molokai
 ROUGE_CSS=style

--- a/p4-16/discussions/P4-16-discussion.pptx.license
+++ b/p4-16/discussions/P4-16-discussion.pptx.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/discussions/P4-16-draft-spec.docx.license
+++ b/p4-16/discussions/P4-16-draft-spec.docx.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/discussions/P4-16-draft-spec.pptx.license
+++ b/p4-16/discussions/P4-16-draft-spec.pptx.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2017 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/discussions/README.md
+++ b/p4-16/discussions/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 This folder contains the following P4 files, all written in P4-16:
 
 - switch.p4: This is the original switch.p4 translated into P4-16.

--- a/p4-16/discussions/migration-guide.pptx.license
+++ b/p4-16/discussions/migration-guide.pptx.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/discussions/p4-16-design-document.docx.license
+++ b/p4-16/discussions/p4-16-design-document.docx.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2015 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/discussions/p4_16-samples.pptx.license
+++ b/p4-16/discussions/p4_16-samples.pptx.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/discussions/simple-switch-example.p4
+++ b/p4-16/discussions/simple-switch-example.p4
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "stdlib.p4"
 
 // Architecture definition file

--- a/p4-16/discussions/simple.p4
+++ b/p4-16/discussions/simple.p4
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef _SIMPLE_P4_
 #define _SIMPLE_P4_
 

--- a/p4-16/discussions/stdlib.p4
+++ b/p4-16/discussions/stdlib.p4
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #ifndef _STDLIB_P4_
 #define _STDLIB_P4_
 

--- a/p4-16/discussions/switch.p4
+++ b/p4-16/discussions/switch.p4
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 #include "core.p4"
 #include "v1model.p4"
 

--- a/p4-16/spec/.gitignore
+++ b/p4-16/spec/.gitignore
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 build/
 grammar.trimmed.adoc
 P4-16-spec.html

--- a/p4-16/spec/Makefile
+++ b/p4-16/spec/Makefile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 SPEC=P4-16-spec
 ROUGE_STYLE=github
 ROUGE_CSS=style

--- a/p4-16/spec/README.md
+++ b/p4-16/spec/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2016 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 This folder contains the sources for generating the official P4-16
 specification document.
 

--- a/p4-16/spec/docs/P4-LDWG-Old-Notes.pdf.license
+++ b/p4-16/spec/docs/P4-LDWG-Old-Notes.pdf.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2023 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/spec/docs/experimenting-with-p4c-bison-grammar-changes.md
+++ b/p4-16/spec/docs/experimenting-with-p4c-bison-grammar-changes.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2023 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Introduction
 
 This article describes how to run `bison` on the P4_16 language

--- a/p4-16/spec/docs/implementing-generalized-switch-statements.md
+++ b/p4-16/spec/docs/implementing-generalized-switch-statements.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2020 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Implementing generalized P4_16 switch statements
 
 Version 1.2.1 and earlier of the P4_16 language specification

--- a/p4-16/spec/docs/p4-table-and-parser-value-set-sizes.md
+++ b/p4-16/spec/docs/p4-table-and-parser-value-set-sizes.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2018 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Size property of P4 tables and parser value sets
 
 It would be convenient for users of P4 programmable devices if objects

--- a/p4-16/spec/install-asciidoctor-linux.sh
+++ b/p4-16/spec/install-asciidoctor-linux.sh
@@ -1,6 +1,9 @@
 #! /bin/bash
 
 # Copyright 2024 Andy Fingerhut
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/p4-16/spec/resources/figs/.gitignore
+++ b/p4-16/spec/resources/figs/.gitignore
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 stem*

--- a/p4-16/spec/resources/figs/README.md
+++ b/p4-16/spec/resources/figs/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 This directory contains files in PNG format of the figures in the
 P4_16 language specification.
 

--- a/p4-16/spec/resources/fonts/verify-font
+++ b/p4-16/spec/resources/fonts/verify-font
@@ -1,3 +1,13 @@
+# SPDX-FileCopyrightText: 2012 Dan Allen
+# SPDX-FileCopyrightText: 2012 Ryan Waldron
+# SPDX-FileCopyrightText: 2012 Sarah White
+# SPDX-FileCopyrightText: 2012 the individual contributors to Asciidoctor
+#
+# SPDX-License-Identifier: MIT
+
+# Source: The Asciidoctor PDF documentation.
+# Retrieved 2025 from https://docs.asciidoctor.org/pdf-converter/latest/theme/prepare-custom-font/
+
 require 'ttfunk'
 require 'ttfunk/subset_collection'
 

--- a/p4-16/spec/resources/theme/logo.png.license
+++ b/p4-16/spec/resources/theme/logo.png.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0

--- a/p4-16/spec/resources/theme/p4-stylesheet.css
+++ b/p4-16/spec/resources/theme/p4-stylesheet.css
@@ -1,4 +1,5 @@
 @import url(//cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+/* SPDX-License-Identifier: MIT */
 /* normalize.css v2.1.1 | MIT License | git.io/normalize */
 /* ========================================================================== HTML5 display definitions ========================================================================== */
 /** Correct `block` display not defined in IE 8/9. */

--- a/p4-16/spec/resources/theme/p4-stylesheet.css.license
+++ b/p4-16/spec/resources/theme/p4-stylesheet.css.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2013 Jonathan Neal
+SPDX-FileCopyrightText: 2013 Nicolas Gallagher
+
+SPDX-License-Identifier: MIT

--- a/p4-16/spec/resources/theme/p4-theme.yml
+++ b/p4-16/spec/resources/theme/p4-theme.yml
@@ -1,3 +1,8 @@
+# Copyright 2024 The P4 Language Consortium
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 extends: ~
 font:
   catalog:

--- a/p4-16/spec/scripts/README.md
+++ b/p4-16/spec/scripts/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2022 The P4 Language Consortium
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Comparing the specification `grammar.mdk` file against `p4c`'s grammar
 
 Assuming you have a local copy of a clone of the p4lang/p4c repository

--- a/p4-16/spec/scripts/compare-grammar.sh
+++ b/p4-16/spec/scripts/compare-grammar.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+# SPDX-FileCopyrightText: 2022 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 THIS_SCRIPT_FILE_MAYBE_RELATIVE="$0"
 THIS_SCRIPT_DIR_MAYBE_RELATIVE="${THIS_SCRIPT_FILE_MAYBE_RELATIVE%/*}"
 THIS_SCRIPT_DIR_ABSOLUTE=`readlink -f "${THIS_SCRIPT_DIR_MAYBE_RELATIVE}"`

--- a/p4-16/spec/scripts/trim-p4-grammar-file.py
+++ b/p4-16/spec/scripts/trim-p4-grammar-file.py
@@ -1,5 +1,9 @@
 #! /usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2022 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import os, sys
 import fileinput
 import re

--- a/p4-16/spec/setup-for-ubuntu-linux.sh
+++ b/p4-16/spec/setup-for-ubuntu-linux.sh
@@ -1,5 +1,9 @@
 #! /bin/bash
 
+# SPDX-FileCopyrightText: 2018 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 print_supported_os_versions() {
     1>&2 echo "    Ubuntu 16.04"
     1>&2 echo "    Ubuntu 18.04"

--- a/p4-16/spec/trim-asciidoc-tag-comments.py
+++ b/p4-16/spec/trim-asciidoc-tag-comments.py
@@ -1,5 +1,9 @@
 #! /usr/bin/env python3
 
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 import fileinput
 import re
 

--- a/tools/Dockerfile.asciidoc_v1
+++ b/tools/Dockerfile.asciidoc_v1
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM ubuntu:22.04
 LABEL maintainer="Language Design Working Group <p4-design@lists.p4.org>"
 LABEL description="Dockerfile used for building the asciidoc specification"

--- a/tools/Dockerfile.asciidoc_v2
+++ b/tools/Dockerfile.asciidoc_v2
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 The P4 Language Consortium
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM  ruby:3.3.5
 LABEL maintainer="Language Design Working Group <p4-design@lists.p4.org>"
 LABEL description="Dockerfile used for building the asciidoc specification"


### PR DESCRIPTION
that did not have it before.

I used "The P4 Language Consortium" for all files where the person to add the file to the repository was someone known to be active in the P4 community at the time they added the file, and there was no explicit copyright notice in the file itself.

There are two files used to generate PDF and/or HTML output from the Asciidoc source, which were copied from other places and released under the MIT license.  I retained the original copyright notices and MIT license for those.