### PR TITLE
fix: replace Docker build with native asciidoctor install in any-branch-uploads

### DIFF
--- a/.github/workflows/any-branch-uploads.yml
+++ b/.github/workflows/any-branch-uploads.yml
@@ -1,21 +1,23 @@
 # SPDX-FileCopyrightText: 2024 The P4 Language Consortium
 #
 # SPDX-License-Identifier: Apache-2.0
-
 name: Any branch uploads
-
 on: workflow_dispatch
-
 jobs:
   any-branch-uploads:
     if: ${{ github.repository == 'p4lang/p4-spec' }}
-    runs-on: [ubuntu-latest]
+    runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Install asciidoc
+      run: sudo ./p4-16/spec/install-asciidoctor-linux.sh
     - name: Build spec
       run: |
-        docker run -v `pwd`/docs/v1:/usr/src/p4-spec p4lang/p4-spec-asciidoc:latest make
-        ls docs/v1/build
+        source /usr/local/rvm/scripts/rvm
+        make -C p4-16/spec
+        ls p4-16/spec
     - name: Upload spec to S3 if needed
       if: ${{ github.actor != 'dependabot[bot]' }}
       uses: jakejarvis/s3-sync-action@v0.5.1


### PR DESCRIPTION
Closes #1404

The any-branch-uploads workflow used a Docker image
p4lang/p4-spec-asciidoc:latest whose source is not publicly visible,
making the build environment difficult to audit.

This replaces the Docker-based build with the same native
install-asciidoctor-linux.sh approach used in asciidoc-build.yml,
making both workflows consistent and fully auditable.

Also updates actions/checkout from v3 to v4 and pins
ubuntu-latest to ubuntu-24.04 for reproducibility.