### PR TITLE
Clarify that Booleans are serializable

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -1890,8 +1890,10 @@ Operations on values of type `match_kind` are described in
 ==== The Boolean type
 
 The Boolean type `bool` contains just two values, `false` and `true`.
-Boolean values are not integers or bit-strings. Operations that can
-be performed on booleans are described in Section <<sec-bool-exprs>>.
+Boolean values are not integers or bit-strings. Boolean values can be
+serialized and deserialized, where `false` is serialized as 0 and `true`
+is serialized as 1. Operations that can be performed on booleans are
+described in Section <<sec-bool-exprs>>.
 
 [#sec-string-type]
 ==== Strings


### PR DESCRIPTION
Following the LDWG discussion on #1389, this PR clarifies in **7.1.4. The Boolean Type** that boolean types are serializable, where `true` means `1` and `false` means `0`.

Booleans were actually already implied to be serializable in the original spec, as `bool` was allowed within `header` types. Thus, this PR makes this point explicit by adding a sentence to the spec.