### PR TITLE
Allow division and modulo operations on fixed-width bit (unsinged) types

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -3636,6 +3636,12 @@ to bit-strings of the same width:
   and is computed by truncating the result to the output's width.
   P4 architectures may impose additional restrictions --- e.g., they may only
   allow multiplication by a non-negative integer power of two.
+* Truncating integer division between positive values, denoted by `/`.
+  The result has the same width as the operands. Similar to multiplication,
+  P4 architectures may impose additional restrictions.
+* Modulo between positive values, denoted by `%`.
+  The result has the same width as the operands. Similar to multiplication,
+  P4 architectures may impose additional restrictions.
 * Bitwise "and" between two bit-strings of the same width, denoted by `&`.
 * Bitwise "or" between two bit-strings of the same width, denoted by `|`.
 * Bitwise "complement" of a single bit-string, denoted by `~`.

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -3636,7 +3636,7 @@ to bit-strings of the same width:
   and is computed by truncating the result to the output's width.
   P4 architectures may impose additional restrictions --- e.g., they may only
   allow multiplication by a non-negative integer power of two.
-* Truncating integer division between positive values, denoted by `/`.
+* Truncating integer division, denoted by `/`.
   The result has the same width as the operands. Similar to multiplication,
   P4 architectures may impose additional restrictions.
 * Modulo between positive values, denoted by `%`.

--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -3637,6 +3637,7 @@ to bit-strings of the same width:
   P4 architectures may impose additional restrictions --- e.g., they may only
   allow multiplication by a non-negative integer power of two.
 * Truncating integer division, denoted by `/`.
+  The denominator must be positive.
   The result has the same width as the operands. Similar to multiplication,
   P4 architectures may impose additional restrictions.
 * Modulo between positive values, denoted by `%`.


### PR DESCRIPTION
This is a follow-up PR from #1327.

The current specification only allows division and modulo for arbitrary-precision integer types (`int`), but not for `bit<W>` or `int<S>` types. Yet, there were uses of division and modulo on `bit<W>` and `int<S>` types in p4c tests (where p4c allows such, under certain p4c-specific restrictions).

This was first discussed in Nov-2025 LDWG meeting, where @jonathan-dilorenzo summarized as:

> Allow any bit divisions and modulo, noting that targets may restrict this behavior arbitrarily. Suggestion from P4 LDWG is to send a PR to support this.

However, no follow-up PR was made, thus this has gone through another round of discussion in May-2026 LDWG meeting. The consensus is the same: allow division and modulo for `bit<W>` types, yet disallow for `int<S>` types since there is no clear consensus on how division and modulo should be defined regarding signedness and rounding.

This PR adds division and modulo to **8.7. Operations on fixed-width bit types (unsigned integers)**, also mentioning that P4 architectures may restrict division and modulo.