### PR TITLE
Refine `parserStatement` grammar

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -6029,11 +6029,15 @@ The syntax for parser statements is given by the following grammar rules:
 
 [source,bison]
 ----
-include::grammar.adoc[tag=parserStatements]
-
 include::grammar.adoc[tag=parserStatement]
 
+include::grammar.adoc[tag=parserStatementOrDeclaration]
+
+include::grammar.adoc[tag=parserStatOrDeclList]
+
 include::grammar.adoc[tag=parserBlockStatement]
+
+include::grammar.adoc[tag=parserConditionalStatement]
 ----
 
 Architectures may place restrictions on the expressions and statements

--- a/p4-16/spec/grammar.adoc
+++ b/p4-16/spec/grammar.adoc
@@ -323,34 +323,47 @@ parserStates
 // tag::parserState[]
 parserState
     : optAnnotations STATE name
-      "{" parserStatements transitionStatement "}"
+      "{" parserStatOrDeclList transitionStatement "}"
     ;
 // end::parserState[]
 
-// tag::parserStatements[]
-parserStatements
-    : /* empty */
-    | parserStatements parserStatement
+// tag::parserStatementOrDeclaration[]
+parserStatementOrDeclaration
+    : variableDeclaration
+    | constantDeclaration
+    | parserStatement
     ;
-// end::parserStatements[]
+// end::parserStatementOrDeclaration[]
+
+// tag::parserStatOrDeclList[]
+parserStatOrDeclList
+    : /* empty */
+    | parserStatOrDeclList parserStatementOrDeclaration
+    ;
+// end::parserStatOrDeclList[]
 
 // tag::parserStatement[]
 parserStatement
     : assignmentOrMethodCallStatement
     | directApplication
     | emptyStatement
-    | variableDeclaration
-    | constantDeclaration
     | parserBlockStatement
-    | conditionalStatement
+    | parserConditionalStatement
     ;
 // end::parserStatement[]
 
 // tag::parserBlockStatement[]
 parserBlockStatement
-    : optAnnotations "{" parserStatements "}"
+    : optAnnotations "{" parserStatOrDeclList "}"
     ;
 // end::parserBlockStatement[]
+
+// tag::parserConditionalStatement[]
+parserConditionalStatement
+    : IF "(" expression ")" parserStatement
+    | IF "(" expression ")" parserStatement ELSE parserStatement
+    ;
+// end::parserConditionalStatement[]
 
 // tag::transitionStatement[]
 transitionStatement


### PR DESCRIPTION
This is a follow-up from #1375.

Previously, `parserStatment` grammar was defined as:

```
parserStatement
    : assignmentOrMethodCallStatement
    | directApplication
    | emptyStatement
    | variableDeclaration
    | constantDeclaration
    | parserBlockStatement
    | conditionalStatement
    ;

conditionalStatement
    : IF "(" expression ")" statement
    | IF "(" expression ")" statement ELSE statement
    ;
```

where the `conditionalStatement` actually led to ordinary `statement`s (which allow more production than `parserStatement`s) being syntactically included within `parserStatement`.

This PR amends the `parserStatement` grammar such that it is closed under itself, without a path to `statement`. In short, the grammar is refined as follows:

```diff
 // tag::parserState[]
 parserState
     : optAnnotations STATE name
-      "{" parserStatements transitionStatement "}"
+      "{" parserStatOrDeclList transitionStatement "}"
     ;
 // end::parserState[]

-// tag::parserStatements[]
-parserStatements
+// tag::parserStatementOrDeclaration[]
+parserStatementOrDeclaration
+    : variableDeclaration
+    | constantDeclaration
+    | parserStatement
+    ;
+// end::parserStatementOrDeclaration[]
+
+// tag::parserStatOrDeclList[]
+parserStatOrDeclList
     : /* empty */
-    | parserStatements parserStatement
+    | parserStatOrDeclList parserStatementOrDeclaration
     ;
-// end::parserStatements[]
+// end::parserStatOrDeclList[]

 // tag::parserStatement[]
 parserStatement
     : assignmentOrMethodCallStatement
     | directApplication
     | emptyStatement
-    | variableDeclaration
-    | constantDeclaration
     | parserBlockStatement
-    | conditionalStatement
+    | parserConditionalStatement
     ;
 // end::parserStatement[]

 // tag::parserBlockStatement[]
 parserBlockStatement
-    : optAnnotations "{" parserStatements "}"
+    : optAnnotations "{" parserStatOrDeclList "}"
     ;
 // end::parserBlockStatement[]

+// tag::parserConditionalStatement[]
+parserConditionalStatement
+    : IF "(" expression ")" parserStatement
+    | IF "(" expression ")" parserStatement ELSE parserStatement
+    ;
+// end::parserConditionalStatement[]
+
```

Similar to how `statement` is defined,

* this adds `parserStatementOrDeclaration`, `parserStatOrDeclList` to the grammar, where `parserBlockStatement` and `parserState` has `parserStatOrDeclList` as its field, and
* `parserStatement` has a new `parserConditionalStatement` variant with explicit then- and else- branches that are `parserStatement`s.

A mirror of this PR in `p4c` is also made: https://github.com/p4lang/p4c/pull/5638. I've checked with `p4-16/spec/scriptscompare-grammar.sh` that the grammar consistent with the p4c PR.