### PR TITLE
Specify that the size of an array must be a local compile-time known value

### DIFF
--- a/p4-16/spec/P4-16-spec.adoc
+++ b/p4-16/spec/P4-16-spec.adoc
@@ -2414,7 +2414,7 @@ An array is a fixed-size vector of elements of the same type. It is defined as:
 include::grammar.adoc[tag=arrayType]
 ----
 
-where `typeRef` refers to the element type and the expression is a compile-time
+where `typeRef` refers to the element type and the expression is a local compile-time
 known value that is the size of the array.  For an array type such as `arr[n]`,
 `n-1` is the maximum defined index.
 


### PR DESCRIPTION
The spec currently states that the size of an array is a compile-time known value, but not local. On the other hand, the size of a header stack must be a local compile-time known value, according to the spec. This PR revises the spec to specify that the size of array must also be a local compile-time known value.

For reference, `p4c` disallows arrays with a non-local compile-time known value, e.g.
```P4
control proto();
package top(proto p);

control c()(bit<8> n) {
    apply {
        bit<32>[n] arr;
    }
}

top(c(2)) main;
```
yields an error:
```
array.p4(6): [--Werror=type-error] error: bit<32>[?]: Size of header stack type should be a constant
        bit<32>[n] arr;
        ^^^^^^^^^^
```